### PR TITLE
docs: add bilingual (English-Chinese) translations for learning

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,46 +1,80 @@
 ---
 name: code-reviewer
-description: MUST BE USED PROACTIVELY after writing or modifying any code. Reviews against project standards, TypeScript strict mode, and coding conventions. Checks for anti-patterns, security issues, and performance problems.
+description: MUST BE USED PROACTIVELY after writing or modifying any code. Reviews against project standards, TypeScript strict mode, and coding conventions. Checks for anti-patterns, security issues, and performance problems. / 必須在編寫或修改任何程式碼後主動使用。根據專案標準、TypeScript 嚴格模式和編碼慣例進行審查。檢查反模式、安全問題和效能問題。
 model: opus
 ---
 
 Senior code reviewer ensuring high standards for the codebase.
 
+資深程式碼審查員，確保程式碼庫的高標準。
+
 ## Core Setup
+## 核心設定
 
 **When invoked**: Run `git diff` to see recent changes, focus on modified files, begin review immediately.
+
+**調用時**：執行 `git diff` 查看最近的更改，專注於修改的檔案，立即開始審查。
 
 **Feedback Format**: Organize by priority with specific line references and fix examples.
 - **Critical**: Must fix (security, breaking changes, logic errors)
 - **Warning**: Should fix (conventions, performance, duplication)
 - **Suggestion**: Consider improving (naming, optimization, docs)
 
+**回饋格式**：按優先級組織，提供具體的行號引用和修復範例。
+- **Critical（關鍵）**：必須修復（安全性、破壞性更改、邏輯錯誤）
+- **Warning（警告）**：應該修復（慣例、效能、重複）
+- **Suggestion（建議）**：考慮改進（命名、最佳化、文件）
+
 ## Review Checklist
+## 審查清單
 
 ### Logic & Flow
+### 邏輯與流程
 - Logical consistency and correct control flow
 - Dead code detection, side effects intentional
 - Race conditions in async operations
 
+- 邏輯一致性和正確的控制流程
+- 檢測無用程式碼，副作用應是有意為之
+- 非同步操作中的競態條件
+
 ### TypeScript & Code Style
+### TypeScript 與程式碼風格
 - **No `any`** - use `unknown`
 - **Prefer `interface`** over `type` (except unions/intersections)
 - **No type assertions** (`as Type`) without justification
 - Proper naming (PascalCase components, camelCase functions, `is`/`has` booleans)
 
+- **禁止 `any`** - 使用 `unknown`
+- **優先使用 `interface`** 而非 `type`（聯合/交叉類型除外）
+- **禁止類型斷言** (`as Type`) 除非有充分理由
+- 正確命名（元件用 PascalCase，函式用 camelCase，布林值用 `is`/`has` 前綴）
+
 ### Immutability & Pure Functions
+### 不可變性與純函數
 - **No data mutation** - use spread operators, immutable updates
 - **No nested if/else** - use early returns, max 2 nesting levels
 - Small focused functions, composition over inheritance
 
+- **禁止資料突變** - 使用展開運算符，不可變更新
+- **禁止巢狀 if/else** - 使用提前返回，最多 2 層巢狀
+- 小而專注的函式，組合優於繼承
+
 ### Loading & Empty States (Critical)
+### 載入與空狀態（關鍵）
 - **Loading ONLY when no data** - `if (loading && !data)` not just `if (loading)`
 - **Every list MUST have empty state** - `ListEmptyComponent` required
 - **Error state ALWAYS first** - check error before loading
 - **State order**: Error → Loading (no data) → Empty → Success
 
+- **僅在無資料時顯示載入** - `if (loading && !data)` 而非僅 `if (loading)`
+- **每個列表必須有空狀態** - 需要 `ListEmptyComponent`
+- **錯誤狀態始終優先** - 在載入之前檢查錯誤
+- **狀態順序**：錯誤 → 載入（無資料）→ 空 → 成功
+
 ```typescript
 // CORRECT - Proper state handling order
+// 正確 - 正確的狀態處理順序
 if (error) return <ErrorState error={error} onRetry={refetch} />;
 if (loading && !data) return <LoadingSkeleton />;
 if (!data?.items.length) return <EmptyState />;
@@ -48,18 +82,30 @@ return <ItemList items={data.items} />;
 ```
 
 ### Error Handling
+### 錯誤處理
 - **NEVER silent errors** - always show user feedback
 - **Mutations need onError** - with toast AND logging
 - Include context: operation names, resource IDs
 
+- **絕不靜默錯誤** - 始終向用戶顯示反饋
+- **變更需要 onError** - 包含 toast 提示和日誌記錄
+- 包含上下文：操作名稱、資源 ID
+
 ### Mutation UI Requirements (Critical)
+### 變更 UI 要求（關鍵）
 - **Button must be `isDisabled` during mutation** - prevent double-clicks
 - **Button must show `isLoading` state** - visual feedback
 - **onError must show toast** - user knows it failed
 - **onCompleted success toast** - optional, use for important actions
 
+- **變更期間按鈕必須 `isDisabled`** - 防止雙擊
+- **按鈕必須顯示 `isLoading` 狀態** - 視覺反饋
+- **onError 必須顯示 toast** - 讓用戶知道失敗
+- **onCompleted 成功 toast** - 可選，用於重要操作
+
 ```typescript
 // CORRECT - Complete mutation pattern
+// 正確 - 完整的變更模式
 const [submit, { loading }] = useSubmitMutation({
   onError: (error) => {
     console.error('submit failed:', error);
@@ -77,40 +123,57 @@ const [submit, { loading }] = useSubmitMutation({
 ```
 
 ### Testing Requirements
+### 測試要求
 - Behavior-driven tests, not implementation
 - Factory pattern: `getMockX(overrides?: Partial<X>)`
 
+- 行為驅動測試，而非實現驅動
+- 工廠模式：`getMockX(overrides?: Partial<X>)`
+
 ### Security & Performance
+### 安全與性能
 - No exposed secrets/API keys
 - Input validation at boundaries
 - Error boundaries for components
 - Image optimization, bundle size awareness
 
+- 不暴露秘密/API 密鑰
+- 邊界處的輸入驗證
+- 組件的錯誤邊界
+- 圖像優化，注意打包大小
+
 ## Code Patterns
+## 程式碼模式
 
 ```typescript
 // Mutation
-items.push(newItem);           // Bad
-[...items, newItem];           // Good
+// 變更
+items.push(newItem);           // Bad - 錯誤
+[...items, newItem];           // Good - 正確
 
 // Conditionals
-if (user) { if (user.isActive) { ... } }  // Bad
-if (!user || !user.isActive) return;       // Good
+// 條件語句
+if (user) { if (user.isActive) { ... } }  // Bad - 錯誤
+if (!user || !user.isActive) return;       // Good - 正確
 
 // Loading states
-if (loading) return <Spinner />;           // Bad - flashes on refetch
-if (loading && !data) return <Spinner />;  // Good - only when no data
+// 載入狀態
+if (loading) return <Spinner />;           // Bad - 錯誤，重新獲取時會閃爍
+if (loading && !data) return <Spinner />;  // Good - 正確，僅在無資料時顯示
 
 // Button during mutation
-<Button onPress={submit}>Submit</Button>                    // Bad - can double-click
-<Button onPress={submit} isDisabled={loading} isLoading={loading}>Submit</Button> // Good
+// 變更期間的按鈕
+<Button onPress={submit}>Submit</Button>                    // Bad - 錯誤，可能雙擊
+<Button onPress={submit} isDisabled={loading} isLoading={loading}>Submit</Button> // Good - 正確
 
 // Empty states
-<FlatList data={items} />                  // Bad - no empty state
-<FlatList data={items} ListEmptyComponent={<EmptyState />} /> // Good
+// 空狀態
+<FlatList data={items} />                  // Bad - 錯誤，沒有空狀態
+<FlatList data={items} ListEmptyComponent={<EmptyState />} /> // Good - 正確
 ```
 
 ## Review Process
+## 審查流程
 
 1. **Run checks**: `npm run lint` for automated issues
 2. **Analyze diff**: `git diff` for all changes
@@ -118,9 +181,21 @@ if (loading && !data) return <Spinner />;  // Good - only when no data
 4. **Apply checklist**: TypeScript, React, testing, security
 5. **Common sense filter**: Flag anything that doesn't make intuitive sense
 
+1. **運行檢查**：使用 `npm run lint` 檢查自動化問題
+2. **分析差異**：使用 `git diff` 查看所有更改
+3. **邏輯審查**：逐行閱讀，追蹤執行路徑
+4. **應用清單**：TypeScript、React、測試、安全性
+5. **常識過濾**：標記任何不符合直覺的內容
+
 ## Integration with Other Skills
+## 與其他技能集成
 
 - **react-ui-patterns**: Loading/error/empty states, mutation UI patterns
 - **graphql-schema**: Mutation error handling
 - **core-components**: Design tokens, component usage
 - **testing-patterns**: Factory functions, behavior-driven tests
+
+- **react-ui-patterns**：加載/錯誤/空狀態，變更 UI 模式
+- **graphql-schema**：變更錯誤處理
+- **core-components**：設計令牌，組件使用
+- **testing-patterns**：工廠函數，行為驅動測試

--- a/.claude/agents/github-workflow.md
+++ b/.claude/agents/github-workflow.md
@@ -1,23 +1,36 @@
 ---
 name: github-workflow
-description: Git workflow agent for commits, branches, and PRs. Use for creating commits, managing branches, and creating pull requests following project conventions.
+description: Git workflow agent for commits, branches, and PRs. Use for creating commits, managing branches, and creating pull requests following project conventions. / Git 工作流程代理，用於提交、分支和 PR。用於建立提交、管理分支和建立遵循專案慣例的拉取請求。
 model: sonnet
 ---
 
 GitHub workflow assistant for managing git operations.
 
+GitHub 工作流程助手，用於管理 git 操作。
+
 ## Branch Naming
+## 分支命名
 
 Format: `{initials}/{description}`
+
+格式：`{首字母縮寫}/{描述}`
 
 Examples:
 - `jd/fix-login-button`
 - `jd/add-user-profile`
 - `jd/refactor-api-client`
 
+示例：
+- `jd/fix-login-button`
+- `jd/add-user-profile`
+- `jd/refactor-api-client`
+
 ## Commit Messages
+## 提交訊息
 
 Use Conventional Commits format:
+
+使用 Conventional Commits 格式：
 
 ```
 <type>[optional scope]: <description>
@@ -25,7 +38,14 @@ Use Conventional Commits format:
 [optional body]
 ```
 
+```
+<類型>[可選範圍]: <描述>
+
+[可選正文]
+```
+
 ### Types
+### 類型
 - `feat`: New feature
 - `fix`: Bug fix
 - `docs`: Documentation only
@@ -34,7 +54,16 @@ Use Conventional Commits format:
 - `test`: Adding or updating tests
 - `chore`: Maintenance tasks
 
+- `feat`：新功能
+- `fix`：錯誤修復
+- `docs`：僅文件
+- `style`：格式化，無程式碼更改
+- `refactor`：既不修復也不添加的程式碼更改
+- `test`：新增或更新測試
+- `chore`：維護任務
+
 ### Examples
+### 示例
 ```
 feat(auth): add password reset flow
 fix(cart): prevent duplicate item addition
@@ -44,6 +73,7 @@ test(user): add profile update tests
 ```
 
 ## Creating a Commit
+## 建立提交
 
 1. Check status:
    ```bash
@@ -61,7 +91,24 @@ test(user): add profile update tests
    git commit -m "type(scope): description"
    ```
 
+1. 檢查狀態：
+   ```bash
+   git status
+   git diff --staged
+   ```
+
+2. 暫存更改：
+   ```bash
+   git add <files>
+   ```
+
+3. 使用約定格式建立提交：
+   ```bash
+   git commit -m "type(scope): description"
+   ```
+
 ## Creating a Pull Request
+## 建立拉取請求
 
 1. Push branch:
    ```bash
@@ -81,14 +128,39 @@ test(user): add profile update tests
    )"
    ```
 
+1. 推送分支：
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+2. 建立 PR：
+   ```bash
+   gh pr create --title "type(scope): description" --body "$(cat <<'EOF'
+   ## Summary
+   - Brief description of changes
+
+   ## Test Plan
+   - [ ] Tests pass
+   - [ ] Manual testing done
+   EOF
+   )"
+   ```
+
 ## PR Title Format
+## PR 標題格式
 
 Same as commit messages:
 - `feat(auth): add OAuth2 support`
 - `fix(api): handle timeout errors`
 - `refactor(components): simplify button variants`
 
+與提交訊息相同：
+- `feat(auth): add OAuth2 support`
+- `fix(api): handle timeout errors`
+- `refactor(components): simplify button variants`
+
 ## Workflow Checklist
+## 工作流清單
 
 Before creating PR:
 - [ ] Branch name follows convention
@@ -96,3 +168,10 @@ Before creating PR:
 - [ ] Tests pass locally
 - [ ] No lint errors
 - [ ] Changes are focused (single concern)
+
+建立 PR 之前：
+- [ ] 分支名稱遵循約定
+- [ ] 提交使用約定格式
+- [ ] 測試在本地通過
+- [ ] 無 lint 錯誤
+- [ ] 更改專注（單一關注點）

--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -1,33 +1,52 @@
 ---
-description: Run code quality checks on a directory
+description: Run code quality checks on a directory / 對目錄執行程式碼品質檢查
 allowed-tools: Read, Glob, Grep, Bash(npm:*), Bash(npx:*)
 ---
 
 # Code Quality Review
+# 程式碼品質審查
 
 Review code quality in: $ARGUMENTS
 
+審查程式碼品質於：$ARGUMENTS
+
 ## Instructions
+## 指令說明
 
 1. **Identify files to review**:
+1. **識別要審查的檔案**：
    - Find all `.ts` and `.tsx` files in the directory
+   - 在目錄中找到所有 `.ts` 和 `.tsx` 檔案
    - Exclude test files and generated files
+   - 排除測試檔案和生成的檔案
 
 2. **Run automated checks**:
+2. **執行自動化檢查**：
    ```bash
    npm run lint -- $ARGUMENTS
    npm run typecheck
    ```
 
 3. **Manual review checklist**:
+3. **手動審查檢查清單**：
    - [ ] No TypeScript `any` types
+   - [ ] 沒有 TypeScript `any` 型別
    - [ ] Proper error handling
+   - [ ] 適當的錯誤處理
    - [ ] Loading states handled correctly
+   - [ ] 正確處理載入狀態
    - [ ] Empty states for lists
+   - [ ] 清單的空狀態
    - [ ] Mutations have onError handlers
+   - [ ] 變更操作具有 onError 處理程序
    - [ ] Buttons disabled during async operations
+   - [ ] 非同步操作期間禁用按鈕
 
 4. **Report findings** organized by severity:
+4. **報告發現**按嚴重程度組織：
    - Critical (must fix)
+   - 關鍵（必須修復）
    - Warning (should fix)
+   - 警告（應該修復）
    - Suggestion (could improve)
+   - 建議（可以改進）

--- a/.claude/commands/docs-sync.md
+++ b/.claude/commands/docs-sync.md
@@ -1,32 +1,50 @@
 ---
-description: Check if documentation is in sync with code
+description: Check if documentation is in sync with code / 檢查文件是否與程式碼同步
 allowed-tools: Read, Glob, Grep, Bash(git:*)
 ---
 
 # Documentation Sync
+# 文件同步檢查
 
 Check if documentation matches the current code state.
 
+檢查文件是否與當前程式碼狀態匹配。
+
 ## Instructions
+## 指令說明
 
 1. **Find recent code changes**:
+1. **查找最近的程式碼變更**：
    ```bash
    git log --since="30 days ago" --name-only --pretty=format: -- "*.ts" "*.tsx" | sort -u
    ```
 
 2. **Find related documentation**:
+2. **查找相關文件**：
    - Search `/docs/` for files mentioning changed code
+   - 搜尋 `/docs/` 目錄中提及已變更程式碼的檔案
    - Check README files near changed code
+   - 檢查已變更程式碼附近的 README 檔案
    - Look for TSDoc comments in changed files
+   - 在已變更的檔案中查找 TSDoc 註釋
 
 3. **Verify documentation accuracy**:
+3. **驗證文件準確性**：
    - Do code examples still work?
+   - 程式碼範例是否仍然有效？
    - Are API signatures correct?
+   - API 簽名是否正確？
    - Are prop types up to date?
+   - prop 型別是否為最新？
 
 4. **Report only actual problems**:
+4. **僅報告實際問題**：
    - Documentation is a living document
+   - 文件是活的文檔
    - Only flag things that are WRONG, not missing
+   - 只標記錯誤的內容，而非缺失的內容
    - Don't suggest documentation for documentation's sake
+   - 不要為了文件而建議文件
 
 5. **Output a checklist** of documentation that needs updating
+5. **輸出檢查清單**列出需要更新的文件

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,22 +1,40 @@
 # Onboard
+# 任務導入
 
 You are given the following context:
+
+你將獲得以下上下文：
+
 $ARGUMENTS
 
 ## Instructions
+## 指令說明
 
 > "AI models are geniuses who start from scratch on every task." – Noam Brown
 
 Your job is to **onboard** yourself to the current task.
 
+你的工作是將自己**導入**到當前任務中。
+
 Do this by:
 
+通過以下方式完成：
+
 - Using extended thinking
+- 使用擴展思考
 - Exploring the codebase
+- 探索程式碼庫
 - Asking me questions if needed
+- 必要時向我提問
 
 The goal is to get you fully prepared to start working on the task.
 
+目標是讓你做好充分準備，開始處理任務。
+
 Take as long as you need to get yourself ready. Overdoing it is better than underdoing it.
 
+花你需要的時間來準備自己。做得過多總比做得不夠好。
+
 Record everything in a `.claude/tasks/[TASK_ID]/onboarding.md` file. This file will be used to onboard you to the task in a new session if needed, so make sure it's comprehensive.
+
+將所有內容記錄在 `.claude/tasks/[TASK_ID]/onboarding.md` 檔案中。此檔案將在需要時用於在新會話中導入任務，因此請確保其內容全面完整。

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,31 +1,51 @@
 ---
-description: Review a pull request using project standards
+description: Review a pull request using project standards / 使用專案標準審查拉取請求
 allowed-tools: Read, Glob, Grep, Bash(git:*), Bash(gh:*)
 ---
 
 # PR Review
+# 拉取請求審查
 
 Review the pull request: $ARGUMENTS
 
+審查拉取請求：$ARGUMENTS
+
 ## Instructions
+## 指令說明
 
 1. **Get PR information**:
+1. **獲取 PR 資訊**：
    - Run `gh pr view $ARGUMENTS` to get PR details
+   - 執行 `gh pr view $ARGUMENTS` 以獲取 PR 詳情
    - Run `gh pr diff $ARGUMENTS` to see changes
+   - 執行 `gh pr diff $ARGUMENTS` 以查看變更
 
 2. **Read review standards**:
+2. **閱讀審查標準**：
    - Read `.claude/agents/code-reviewer.md` for the review checklist
+   - 閱讀 `.claude/agents/code-reviewer.md` 以獲取審查檢查清單
 
 3. **Apply the checklist** to all changed files:
+3. **將檢查清單應用**到所有變更的檔案：
    - TypeScript strict mode compliance
+   - TypeScript 嚴格模式合規性
    - Error handling patterns
+   - 錯誤處理模式
    - Loading/error/empty states
+   - 載入/錯誤/空狀態
    - Test coverage
+   - 測試覆蓋率
    - Documentation updates
+   - 文件更新
 
 4. **Provide structured feedback**:
+4. **提供結構化回饋**：
    - **Critical**: Must fix before merge
+   - **關鍵**：合併前必須修復
    - **Warning**: Should fix
+   - **警告**：應該修復
    - **Suggestion**: Nice to have
+   - **建議**：最好能有
 
 5. **Post review comments** using `gh pr comment`
+5. **發布審查評論**使用 `gh pr comment`

--- a/.claude/commands/pr-summary.md
+++ b/.claude/commands/pr-summary.md
@@ -1,27 +1,38 @@
 ---
-description: Generate a summary for the current branch changes
+description: Generate a summary for the current branch changes / 為當前分支變更生成摘要
 allowed-tools: Bash(git:*)
 ---
 
 # PR Summary
+# 拉取請求摘要
 
 Generate a pull request summary for the current branch.
 
+為當前分支生成拉取請求摘要。
+
 ## Instructions
+## 指令說明
 
 1. **Analyze changes**:
+1. **分析變更**：
    ```bash
    git log main..HEAD --oneline
    git diff main...HEAD --stat
    ```
 
 2. **Generate summary** with:
+2. **生成摘要**包括：
    - Brief description of what changed
+   - 變更內容的簡要描述
    - List of files modified
+   - 修改的檔案清單
    - Breaking changes (if any)
+   - 破壞性變更（如果有）
    - Testing notes
+   - 測試說明
 
 3. **Format as PR body**:
+3. **格式化為 PR 正文**：
    ```markdown
    ## Summary
    [1-3 bullet points describing the changes]

--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -1,17 +1,24 @@
 ---
-description: Work on a JIRA/Linear ticket end-to-end
+description: Work on a JIRA/Linear ticket end-to-end / 端到端處理 JIRA/Linear 工單
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gh:*), Bash(npm:*), mcp__jira__*, mcp__github__*, mcp__linear__*
 ---
 
 # Ticket Workflow
+# 工單工作流程
 
 Work on ticket: $ARGUMENTS
 
+處理工單：$ARGUMENTS
+
 ## Instructions
+## 指令說明
 
 ### 1. Read the Ticket
+### 1. 閱讀工單
 
 First, fetch and understand the ticket:
+
+首先，獲取並理解工單：
 
 ```
 Use the JIRA/Linear MCP tools to:
@@ -20,53 +27,101 @@ Use the JIRA/Linear MCP tools to:
 - Review any comments or attachments
 ```
 
+```
+使用 JIRA/Linear MCP 工具：
+- 獲取工單詳情（標題、描述、驗收標準）
+- 檢查關聯的工單或史詩
+- 查看任何評論或附件
+```
+
 Summarize:
+
+總結：
+
 - What needs to be done
+- 需要完成什麼
 - Acceptance criteria
+- 驗收標準
 - Any blockers or dependencies
+- 任何阻礙或依賴
 
 ### 2. Explore the Codebase
+### 2. 探索程式碼庫
 
 Before coding:
+
+開始編碼前：
+
 - Search for related code
+- 搜尋相關程式碼
 - Understand the current implementation
+- 理解當前實作
 - Identify files that need changes
+- 識別需要變更的檔案
 
 ### 3. Create a Branch
+### 3. 建立分支
 
 ```bash
 git checkout -b {initials}/{ticket-id}-{brief-description}
 ```
 
 ### 4. Implement the Changes
+### 4. 實作變更
 
 - Follow project patterns (check relevant skills)
+- 遵循專案模式（檢查相關技能）
 - Write tests first (TDD)
+- 先寫測試（TDD）
 - Make incremental commits
+- 進行增量提交
 
 ### 5. Update the Ticket
+### 5. 更新工單
 
 As you work:
+
+工作時：
+
 - Add comments with progress updates
+- 添加進度更新評論
 - Update status (In Progress → In Review)
+- 更新狀態（進行中 → 審查中）
 - Log any blockers or questions
+- 記錄任何阻礙或問題
 
 ### 6. Create PR and Link
+### 6. 建立並連結 PR
 
 When ready:
+
+準備就緒時：
+
 - Create PR with `gh pr create`
+- 使用 `gh pr create` 建立 PR
 - Link the PR to the ticket
+- 將 PR 連結到工單
 - Add ticket ID to PR title: `feat(PROJ-123): description`
+- 在 PR 標題中添加工單 ID：`feat(PROJ-123): description`
 
 ### 7. If You Find a Bug
+### 7. 如果發現錯誤
 
 If you discover an unrelated bug while working:
+
+如果在工作時發現無關的錯誤：
+
 1. Create a new ticket with details
+1. 建立新工單並提供詳細資訊
 2. Link it to the current ticket if related
+2. 如果相關，將其連結到當前工單
 3. Note it in the PR description
+3. 在 PR 描述中註明
 4. Continue with original task
+4. 繼續完成原始任務
 
 ## Example Workflow
+## 工作流程範例
 
 ```
 Me: /ticket PROJ-123

--- a/.claude/settings.md
+++ b/.claude/settings.md
@@ -1,48 +1,82 @@
 # Claude Code Settings Documentation
+# Claude Code 設定文檔
 
 ## Environment Variables
+## 環境變數
 
 - `INSIDE_CLAUDE_CODE`: "1" - Indicates code is running inside Claude Code
+- `INSIDE_CLAUDE_CODE`: "1" - 表示程式碼正在 Claude Code 中執行
+
 - `BASH_DEFAULT_TIMEOUT_MS`: Default timeout for bash commands (7 minutes)
+- `BASH_DEFAULT_TIMEOUT_MS`: bash 命令的預設超時時間（7 分鐘）
+
 - `BASH_MAX_TIMEOUT_MS`: Maximum timeout for bash commands
+- `BASH_MAX_TIMEOUT_MS`: bash 命令的最大超時時間
 
 ## Hooks
+## 鉤子
 
 ### UserPromptSubmit
+### 使用者提示提交
 
 - **Skill Evaluation**: Analyzes prompts and suggests relevant skills
+- **技能評估**: 分析提示並建議相關技能
   - **Script**: `.claude/hooks/skill-eval.sh`
+  - **腳本**: `.claude/hooks/skill-eval.sh`
   - **Behavior**: Matches keywords, file paths, and patterns to suggest skills
+  - **行為**: 匹配關鍵字、檔案路徑和模式以建議技能
 
 ### PreToolUse
+### 工具使用前
 
 - **Main Branch Protection**: Prevents edits on main branch (5s timeout)
+- **主分支保護**: 防止在主分支上進行編輯（5 秒超時）
   - **Triggers**: Before editing files with Edit, MultiEdit, or Write tools
+  - **觸發時機**: 在使用 Edit、MultiEdit 或 Write 工具編輯檔案之前
   - **Behavior**: Blocks file edits when on main branch, suggests creating feature branch
+  - **行為**: 當在主分支時阻止檔案編輯，建議建立功能分支
 
 ### PostToolUse
+### 工具使用後
 
 1. **Code Formatting**: Auto-format JS/TS files (30s timeout)
+1. **程式碼格式化**: 自動格式化 JS/TS 檔案（30 秒超時）
    - **Triggers**: After editing `.js`, `.jsx`, `.ts`, `.tsx` files
+   - **觸發時機**: 編輯 `.js`、`.jsx`、`.ts`、`.tsx` 檔案後
    - **Command**: `npx prettier --write` (or Biome)
+   - **命令**: `npx prettier --write`（或 Biome）
    - **Behavior**: Formats code, shows feedback if errors found
+   - **行為**: 格式化程式碼，如果發現錯誤則顯示回饋
 
 2. **NPM Install**: Auto-install after package.json changes (60s timeout)
+2. **NPM 安裝**: 在 package.json 變更後自動安裝（60 秒超時）
    - **Triggers**: After editing `package.json` files
+   - **觸發時機**: 編輯 `package.json` 檔案後
    - **Command**: `npm install`
+   - **命令**: `npm install`
    - **Behavior**: Installs dependencies, fails edit if installation fails
+   - **行為**: 安裝依賴項，如果安裝失敗則編輯失敗
 
 3. **Test Runner**: Run tests after test file changes (90s timeout)
+3. **測試執行器**: 在測試檔案變更後執行測試（90 秒超時）
    - **Triggers**: After editing `.test.js`, `.test.jsx`, `.test.ts`, `.test.tsx` files
+   - **觸發時機**: 編輯 `.test.js`、`.test.jsx`、`.test.ts`、`.test.tsx` 檔案後
    - **Command**: `npm test -- --findRelatedTests <file> --passWithNoTests`
+   - **命令**: `npm test -- --findRelatedTests <file> --passWithNoTests`
    - **Behavior**: Runs related tests, shows results, non-blocking
+   - **行為**: 執行相關測試，顯示結果，非阻塞式
 
 4. **TypeScript Check**: Type-check TS/TSX files (30s timeout)
+4. **TypeScript 檢查**: 對 TS/TSX 檔案進行類型檢查（30 秒超時）
    - **Triggers**: After editing `.ts`, `.tsx` files
+   - **觸發時機**: 編輯 `.ts`、`.tsx` 檔案後
    - **Command**: `npx tsc --noEmit`
+   - **命令**: `npx tsc --noEmit`
    - **Behavior**: Shows first errors only, non-blocking
+   - **行為**: 僅顯示第一個錯誤，非阻塞式
 
 ## Hook Response Format
+## 鉤子回應格式
 
 ```json
 {
@@ -54,13 +88,25 @@
 ```
 
 ## Environment Variables in Hooks
+## 鉤子中的環境變數
 
 - `$CLAUDE_TOOL_INPUT_FILE_PATH`: File being edited
+- `$CLAUDE_TOOL_INPUT_FILE_PATH`: 正在編輯的檔案
+
 - `$CLAUDE_TOOL_NAME`: Tool being used
+- `$CLAUDE_TOOL_NAME`: 正在使用的工具
+
 - `$CLAUDE_PROJECT_DIR`: Project root directory
+- `$CLAUDE_PROJECT_DIR`: 專案根目錄
 
 ## Exit Codes
+## 退出代碼
 
 - `0`: Success
+- `0`: 成功
+
 - `1`: Non-blocking error (shows feedback)
+- `1`: 非阻塞式錯誤（顯示回饋）
+
 - `2`: Blocking error (PreToolUse only - blocks the action)
+- `2`: 阻塞式錯誤（僅限 PreToolUse - 阻止操作）

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,77 +1,129 @@
 # Claude Code Skills
+# Claude Code 技能
 
 This directory contains project-specific skills that provide Claude with domain knowledge and best practices for this codebase.
 
+此目錄包含專案特定的技能，為 Claude 提供此程式碼庫的領域知識和最佳實踐。
+
 ## Skills by Category
+## 依類別分類的技能
 
 ### Code Quality & Patterns
+### 程式碼品質與模式
 | Skill | Description |
 |-------|-------------|
 | [testing-patterns](./testing-patterns/SKILL.md) | Jest testing, factory functions, mocking strategies, TDD workflow |
+| [testing-patterns](./testing-patterns/SKILL.md) | Jest 測試、工廠函數、模擬策略、TDD 工作流程 |
 | [systematic-debugging](./systematic-debugging/SKILL.md) | Four-phase debugging methodology, root cause analysis |
+| [systematic-debugging](./systematic-debugging/SKILL.md) | 四階段除錯方法論、根本原因分析 |
 
 ### React & UI
+### React 與使用者介面
 | Skill | Description |
 |-------|-------------|
 | [react-ui-patterns](./react-ui-patterns/SKILL.md) | React patterns, loading states, error handling, GraphQL hooks |
+| [react-ui-patterns](./react-ui-patterns/SKILL.md) | React 模式、載入狀態、錯誤處理、GraphQL hooks |
 | [core-components](./core-components/SKILL.md) | Design system components, tokens, component library |
+| [core-components](./core-components/SKILL.md) | 設計系統元件、設計標記、元件庫 |
 | [formik-patterns](./formik-patterns/SKILL.md) | Form handling, validation, submission patterns |
+| [formik-patterns](./formik-patterns/SKILL.md) | 表單處理、驗證、提交模式 |
 
 ### Data & API
+### 資料與 API
 | Skill | Description |
 |-------|-------------|
 | [graphql-schema](./graphql-schema/SKILL.md) | GraphQL queries, mutations, code generation |
+| [graphql-schema](./graphql-schema/SKILL.md) | GraphQL 查詢、變更、程式碼生成 |
 
 ## Skill Combinations for Common Tasks
+## 常見任務的技能組合
 
 ### Building a New Feature
+### 建構新功能
 1. **react-ui-patterns** - Loading/error/empty states
+1. **react-ui-patterns** - 載入/錯誤/空白狀態
 2. **graphql-schema** - Create queries/mutations
+2. **graphql-schema** - 建立查詢/變更
 3. **core-components** - UI implementation
+3. **core-components** - UI 實作
 4. **testing-patterns** - Write tests (TDD)
+4. **testing-patterns** - 編寫測試 (TDD)
 
 ### Building a Form
+### 建構表單
 1. **formik-patterns** - Form structure and validation
+1. **formik-patterns** - 表單結構和驗證
 2. **graphql-schema** - Mutation for submission
+2. **graphql-schema** - 提交的變更操作
 3. **react-ui-patterns** - Loading/error handling
+3. **react-ui-patterns** - 載入/錯誤處理
 
 ### Debugging an Issue
+### 除錯問題
 1. **systematic-debugging** - Root cause analysis
+1. **systematic-debugging** - 根本原因分析
 2. **testing-patterns** - Write failing test first
+2. **testing-patterns** - 先編寫失敗的測試
 
 ## How Skills Work
+## 技能如何運作
 
 Skills are automatically invoked when Claude recognizes relevant context. Each skill provides:
 
+當 Claude 識別到相關情境時，技能會自動被調用。每個技能提供：
+
 - **When to Use** - Trigger conditions
+- **何時使用** - 觸發條件
 - **Core Patterns** - Best practices and examples
+- **核心模式** - 最佳實踐和範例
 - **Anti-Patterns** - What to avoid
+- **反模式** - 應避免的做法
 - **Integration** - How skills connect
+- **整合** - 技能如何連接
 
 ## Adding New Skills
+## 新增技能
 
 1. Create directory: `.claude/skills/skill-name/`
+1. 建立目錄：`.claude/skills/skill-name/`
 2. Add `SKILL.md` (case-sensitive) with YAML frontmatter:
+2. 新增 `SKILL.md`（區分大小寫）並包含 YAML 前置資料：
    ```yaml
    ---
    # Required fields
+   # 必填欄位
    name: skill-name              # Lowercase, hyphens, max 64 chars
+                                 # 小寫、連字號、最多 64 字元
    description: What it does and when to use it. Include trigger keywords.  # Max 1024 chars
+                                                                              # 功能說明和使用時機。包含觸發關鍵字。最多 1024 字元
 
    # Optional fields
+   # 選填欄位
    allowed-tools: Read, Grep, Glob    # Restrict available tools
+                                       # 限制可用工具
    model: claude-sonnet-4-20250514    # Specific model to use
+                                       # 使用特定模型
    ---
    ```
 3. Include standard sections: When to Use, Core Patterns, Anti-Patterns, Integration
+3. 包含標準章節：何時使用、核心模式、反模式、整合
 4. Add to this README
+4. 新增至此 README
 5. Add triggers to `.claude/hooks/skill-rules.json`
+5. 將觸發條件新增至 `.claude/hooks/skill-rules.json`
 
 **Important:** The `description` field is critical—Claude uses semantic matching on it to decide when to apply the skill. Include keywords users would naturally mention.
 
+**重要：** `description` 欄位非常關鍵——Claude 使用語意配對來決定何時應用該技能。請包含使用者自然會提到的關鍵字。
+
 ## Maintenance
+## 維護
 
 - Update skills when patterns change
+- 當模式改變時更新技能
 - Remove outdated information
+- 移除過時的資訊
 - Add new patterns as they emerge
+- 隨著新模式出現而新增
 - Keep examples current with codebase
+- 保持範例與程式碼庫同步

--- a/.claude/skills/core-components/SKILL.md
+++ b/.claude/skills/core-components/SKILL.md
@@ -4,22 +4,32 @@ description: Core component library and design system patterns. Use when buildin
 ---
 
 # Core Components
+# 核心元件
 
 ## Design System Overview
+## 設計系統概述
 
 Use components from your core library instead of raw platform components. This ensures consistent styling and behavior.
 
+使用核心庫中的元件，而非原始平台元件。這確保了一致的樣式和行為。
+
 ## Design Tokens
+## 設計標記
 
 **NEVER hard-code values. Always use design tokens.**
 
+**永遠不要硬編碼值。總是使用設計標記。**
+
 ### Spacing Tokens
+### 間距標記
 
 ```tsx
 // CORRECT - Use tokens
+// 正確 - 使用標記
 <Box padding="$4" marginBottom="$2" />
 
 // WRONG - Hard-coded values
+// 錯誤 - 硬編碼值
 <Box padding={16} marginBottom={8} />
 ```
 
@@ -33,13 +43,16 @@ Use components from your core library instead of raw platform components. This e
 | `$8` | 32px |
 
 ### Color Tokens
+### 顏色標記
 
 ```tsx
 // CORRECT - Semantic tokens
+// 正確 - 語意化標記
 <Text color="$textPrimary" />
 <Box backgroundColor="$backgroundSecondary" />
 
 // WRONG - Hard-coded colors
+// 錯誤 - 硬編碼顏色
 <Text color="#333333" />
 <Box backgroundColor="rgb(245, 245, 245)" />
 ```
@@ -47,13 +60,20 @@ Use components from your core library instead of raw platform components. This e
 | Semantic Token | Use For |
 |----------------|---------|
 | `$textPrimary` | Main text |
+| `$textPrimary` | 主要文字 |
 | `$textSecondary` | Supporting text |
+| `$textSecondary` | 支援文字 |
 | `$textTertiary` | Disabled/hint text |
+| `$textTertiary` | 停用/提示文字 |
 | `$primary500` | Brand/accent color |
+| `$primary500` | 品牌/強調顏色 |
 | `$statusError` | Error states |
+| `$statusError` | 錯誤狀態 |
 | `$statusSuccess` | Success states |
+| `$statusSuccess` | 成功狀態 |
 
 ### Typography Tokens
+### 排版標記
 
 ```tsx
 <Text fontSize="$lg" fontWeight="$semibold" />
@@ -69,10 +89,14 @@ Use components from your core library instead of raw platform components. This e
 | `$2xl` | 24px |
 
 ## Core Components
+## 核心元件
 
 ### Box
+### Box 容器
 
 Base layout component with token support:
+
+支援標記的基礎佈局元件：
 
 ```tsx
 <Box
@@ -85,8 +109,11 @@ Base layout component with token support:
 ```
 
 ### HStack / VStack
+### 水平堆疊 / 垂直堆疊
 
 Horizontal and vertical flex layouts:
+
+水平和垂直彈性佈局：
 
 ```tsx
 <HStack gap="$3" alignItems="center">
@@ -101,8 +128,11 @@ Horizontal and vertical flex layouts:
 ```
 
 ### Text
+### 文字
 
 Typography with token support:
+
+支援標記的排版：
 
 ```tsx
 <Text
@@ -115,8 +145,11 @@ Typography with token support:
 ```
 
 ### Button
+### 按鈕
 
 Interactive button with variants:
+
+具有變體的互動按鈕：
 
 ```tsx
 <Button
@@ -133,13 +166,20 @@ Interactive button with variants:
 | Variant | Use For |
 |---------|---------|
 | `solid` | Primary actions |
+| `solid` | 主要操作 |
 | `outline` | Secondary actions |
+| `outline` | 次要操作 |
 | `ghost` | Tertiary/subtle actions |
+| `ghost` | 第三級/微妙操作 |
 | `link` | Inline actions |
+| `link` | 內聯操作 |
 
 ### Input
+### 輸入框
 
 Form input with validation:
+
+具有驗證的表單輸入：
 
 ```tsx
 <Input
@@ -152,8 +192,11 @@ Form input with validation:
 ```
 
 ### Card
+### 卡片
 
 Content container:
+
+內容容器：
 
 ```tsx
 <Card padding="$4" gap="$3">
@@ -167,8 +210,10 @@ Content container:
 ```
 
 ## Layout Patterns
+## 佈局模式
 
 ### Screen Layout
+### 畫面佈局
 
 ```tsx
 const MyScreen = () => (
@@ -176,12 +221,14 @@ const MyScreen = () => (
     <ScreenHeader title="Page Title" />
     <ScreenContent padding="$4">
       {/* Content */}
+      {/* 內容 */}
     </ScreenContent>
   </Screen>
 );
 ```
 
 ### Form Layout
+### 表單佈局
 
 ```tsx
 <VStack gap="$4" padding="$4">
@@ -192,6 +239,7 @@ const MyScreen = () => (
 ```
 
 ### List Item Layout
+### 列表項目佈局
 
 ```tsx
 <HStack
@@ -211,32 +259,42 @@ const MyScreen = () => (
 ```
 
 ## Anti-Patterns
+## 反模式
 
 ```tsx
 // WRONG - Hard-coded values
+// 錯誤 - 硬編碼值
 <View style={{ padding: 16, backgroundColor: '#fff' }}>
 
 // CORRECT - Design tokens
+// 正確 - 設計標記
 <Box padding="$4" backgroundColor="$backgroundPrimary">
 
 
 // WRONG - Raw platform components
+// 錯誤 - 原始平台元件
 import { View, Text } from 'react-native';
 
 // CORRECT - Core components
+// 正確 - 核心元件
 import { Box, Text } from 'components/core';
 
 
 // WRONG - Inline styles
+// 錯誤 - 內聯樣式
 <Text style={{ fontSize: 18, fontWeight: '600' }}>
 
 // CORRECT - Token props
+// 正確 - 標記屬性
 <Text fontSize="$lg" fontWeight="$semibold">
 ```
 
 ## Component Props Pattern
+## 元件屬性模式
 
 When creating components, use token-based props:
+
+建立元件時，使用基於標記的屬性：
 
 ```tsx
 interface CardProps {
@@ -258,7 +316,11 @@ const Card = ({ padding = '$4', variant = 'elevated', children }: CardProps) => 
 ```
 
 ## Integration with Other Skills
+## 與其他技能的整合
 
 - **react-ui-patterns**: Use core components for UI states
+- **react-ui-patterns**：使用核心元件處理 UI 狀態
 - **testing-patterns**: Mock core components in tests
+- **testing-patterns**：在測試中模擬核心元件
 - **storybook**: Document component variants
+- **storybook**：記錄元件變體

--- a/.claude/skills/formik-patterns/SKILL.md
+++ b/.claude/skills/formik-patterns/SKILL.md
@@ -4,8 +4,10 @@ description: Formik form handling with validation patterns. Use when building fo
 ---
 
 # Formik Patterns
+# Formik 模式
 
 ## Basic Form Setup
+## 基本表單設定
 
 ```tsx
 import { useFormik } from 'formik';
@@ -62,18 +64,22 @@ const LoginForm = () => {
 ```
 
 ## Validation Schemas
+## 驗證模式
 
 ### Common Patterns
+### 常見模式
 
 ```typescript
 import * as yup from 'yup';
 
 // Email
+// 電子郵件
 email: yup.string()
   .email('Invalid email address')
   .required('Email is required')
 
 // Password with requirements
+// 具有要求的密碼
 password: yup.string()
   .min(8, 'Must be at least 8 characters')
   .matches(/[a-z]/, 'Must contain lowercase letter')
@@ -82,33 +88,39 @@ password: yup.string()
   .required('Password is required')
 
 // Confirm password
+// 確認密碼
 confirmPassword: yup.string()
   .oneOf([yup.ref('password')], 'Passwords must match')
   .required('Please confirm password')
 
 // Phone number
+// 電話號碼
 phone: yup.string()
   .matches(/^\+?[1-9]\d{1,14}$/, 'Invalid phone number')
   .required('Phone is required')
 
 // Optional field with validation when present
+// 存在時需驗證的選填欄位
 website: yup.string()
   .url('Must be a valid URL')
   .nullable()
 
 // Number with range
+// 具有範圍的數字
 quantity: yup.number()
   .min(1, 'Minimum 1')
   .max(100, 'Maximum 100')
   .required('Quantity required')
 
 // Array with minimum items
+// 具有最小項目數的陣列
 tags: yup.array()
   .of(yup.string())
   .min(1, 'Select at least one tag')
 ```
 
 ### Conditional Validation
+### 條件驗證
 
 ```typescript
 const schema = yup.object({
@@ -122,8 +134,10 @@ const schema = yup.object({
 ```
 
 ## Form Field Helpers
+## 表單欄位輔助函數
 
 ### Input Helper
+### 輸入輔助函數
 
 ```tsx
 const getFieldProps = (name: keyof typeof formik.values) => ({
@@ -134,10 +148,12 @@ const getFieldProps = (name: keyof typeof formik.values) => ({
 });
 
 // Usage
+// 使用方式
 <Input label="Email" {...getFieldProps('email')} />
 ```
 
 ### Select/Picker Helper
+### 選擇器輔助函數
 
 ```tsx
 <Select
@@ -150,6 +166,7 @@ const getFieldProps = (name: keyof typeof formik.values) => ({
 ```
 
 ## Form Submission with GraphQL
+## 使用 GraphQL 提交表單
 
 ```tsx
 const CreateItemForm = () => {
@@ -179,6 +196,7 @@ const CreateItemForm = () => {
   return (
     <VStack gap="$4">
       {/* Form fields */}
+      {/* 表單欄位 */}
       <Button
         onPress={formik.handleSubmit}
         isDisabled={!formik.isValid || formik.isSubmitting}
@@ -192,6 +210,7 @@ const CreateItemForm = () => {
 ```
 
 ## Edit Form with Initial Values
+## 具有初始值的編輯表單
 
 ```tsx
 const EditItemForm = ({ item }: { item: Item }) => {
@@ -209,6 +228,7 @@ const EditItemForm = ({ item }: { item: Item }) => {
       description: item.description ?? '',
     },
     enableReinitialize: true, // Update when item prop changes
+                              // 當 item prop 改變時更新
     validationSchema,
     onSubmit: async (values) => {
       await updateItem({
@@ -218,11 +238,13 @@ const EditItemForm = ({ item }: { item: Item }) => {
   });
 
   // Track if form has changes
+  // 追蹤表單是否有變更
   const hasChanges = formik.dirty;
 
   return (
     <VStack gap="$4">
       {/* Form fields */}
+      {/* 表單欄位 */}
       <Button
         onPress={formik.handleSubmit}
         isDisabled={!hasChanges || !formik.isValid || formik.isSubmitting}
@@ -236,26 +258,41 @@ const EditItemForm = ({ item }: { item: Item }) => {
 ```
 
 ## Form State Helpers
+## 表單狀態輔助函數
 
 ```tsx
 const {
   values,          // Current form values
+                   // 目前表單值
   errors,          // Validation errors
+                   // 驗證錯誤
   touched,         // Fields that have been touched
+                   // 已觸碰的欄位
   isValid,         // Form passes validation
+                   // 表單通過驗證
   isSubmitting,    // Submit in progress
+                   // 提交進行中
   dirty,           // Values differ from initial
+                   // 值與初始值不同
   handleSubmit,    // Submit handler
+                   // 提交處理器
   handleChange,    // Change handler
+                   // 變更處理器
   handleBlur,      // Blur handler
+                   // 失焦處理器
   setFieldValue,   // Set single field
+                   // 設定單一欄位
   setFieldTouched, // Mark field touched
+                   // 標記欄位已觸碰
   resetForm,       // Reset to initial values
+                   // 重設為初始值
   setSubmitting,   // Control submitting state
+                   // 控制提交狀態
 } = formik;
 ```
 
 ## Multi-Step Forms
+## 多步驟表單
 
 ```tsx
 const MultiStepForm = () => {
@@ -264,12 +301,15 @@ const MultiStepForm = () => {
   const formik = useFormik({
     initialValues: {
       // Step 1
+      // 步驟 1
       name: '',
       email: '',
       // Step 2
+      // 步驟 2
       address: '',
       city: '',
       // Step 3
+      // 步驟 3
       cardNumber: '',
     },
     validationSchema: stepSchemas[step],
@@ -308,15 +348,18 @@ const MultiStepForm = () => {
 ```
 
 ## Anti-Patterns
+## 反模式
 
 ```tsx
 // WRONG - Not showing validation errors
+// 錯誤 - 不顯示驗證錯誤
 <Input
   value={formik.values.email}
   onChangeText={formik.handleChange('email')}
 />
 
 // CORRECT - Show errors when touched
+// 正確 - 觸碰時顯示錯誤
 <Input
   value={formik.values.email}
   onChangeText={formik.handleChange('email')}
@@ -326,9 +369,11 @@ const MultiStepForm = () => {
 
 
 // WRONG - Submit button always enabled
+// 錯誤 - 提交按鈕總是啟用
 <Button onPress={formik.handleSubmit}>Submit</Button>
 
 // CORRECT - Disabled when invalid or submitting
+// 正確 - 無效或提交時停用
 <Button
   onPress={formik.handleSubmit}
   isDisabled={!formik.isValid || formik.isSubmitting}
@@ -339,11 +384,13 @@ const MultiStepForm = () => {
 
 
 // WRONG - No error handling on mutation
+// 錯誤 - 變更沒有錯誤處理
 onSubmit: async (values) => {
   await createItem({ variables: { input: values } });
 }
 
 // CORRECT - Handle errors
+// 正確 - 處理錯誤
 onSubmit: async (values, { setSubmitting }) => {
   try {
     await createItem({ variables: { input: values } });
@@ -356,7 +403,11 @@ onSubmit: async (values, { setSubmitting }) => {
 ```
 
 ## Integration with Other Skills
+## 與其他技能的整合
 
 - **graphql-schema**: Mutation submission patterns
+- **graphql-schema**：變更提交模式
 - **react-ui-patterns**: Loading/error states
+- **react-ui-patterns**：載入/錯誤狀態
 - **testing-patterns**: Test form validation and submission
+- **testing-patterns**：測試表單驗證和提交

--- a/.claude/skills/graphql-schema/SKILL.md
+++ b/.claude/skills/graphql-schema/SKILL.md
@@ -4,15 +4,22 @@ description: GraphQL queries, mutations, and code generation patterns. Use when 
 ---
 
 # GraphQL Schema Patterns
+# GraphQL 模式模式
 
 ## Core Rules
+## 核心規則
 
 1. **NEVER inline `gql` literals** - Create `.gql` files
+1. **永遠不要內聯 `gql` 字串** - 建立 `.gql` 檔案
 2. **ALWAYS run codegen** after creating/modifying `.gql` files
+2. **總是執行 codegen** 在建立/修改 `.gql` 檔案之後
 3. **ALWAYS add `onError` handler** to mutations
+3. **總是加入 `onError` 處理器** 到變更操作
 4. **Use generated hooks** - Never write raw Apollo hooks
+4. **使用生成的 hooks** - 永遠不要編寫原始的 Apollo hooks
 
 ## File Structure
+## 檔案結構
 
 ```
 src/
@@ -20,15 +27,20 @@ src/
 │   └── ItemList/
 │       ├── ItemList.tsx
 │       ├── GetItems.gql           # Query definition
+│       │                          # 查詢定義
 │       └── GetItems.generated.ts  # Auto-generated (don't edit)
+│                                  # 自動生成（不要編輯）
 └── graphql/
     └── mutations/
         └── CreateItem.gql         # Shared mutations
+                                   # 共享變更
 ```
 
 ## Creating a Query
+## 建立查詢
 
 ### Step 1: Create .gql file
+### 步驟 1：建立 .gql 檔案
 
 ```graphql
 # src/components/ItemList/GetItems.gql
@@ -43,12 +55,14 @@ query GetItems($limit: Int, $offset: Int) {
 ```
 
 ### Step 2: Run codegen
+### 步驟 2：執行 codegen
 
 ```bash
 npm run gql:typegen
 ```
 
 ### Step 3: Import and use generated hook
+### 步驟 3：匯入並使用生成的 hook
 
 ```typescript
 import { useGetItemsQuery } from './GetItems.generated';
@@ -67,8 +81,10 @@ const ItemList = () => {
 ```
 
 ## Creating a Mutation
+## 建立變更
 
 ### Step 1: Create .gql file
+### 步驟 1：建立 .gql 檔案
 
 ```graphql
 # src/graphql/mutations/CreateItem.gql
@@ -82,12 +98,14 @@ mutation CreateItem($input: CreateItemInput!) {
 ```
 
 ### Step 2: Run codegen
+### 步驟 2：執行 codegen
 
 ```bash
 npm run gql:typegen
 ```
 
 ### Step 3: Use with REQUIRED error handling
+### 步驟 3：使用並加上必要的錯誤處理
 
 ```typescript
 import { useCreateItemMutation } from 'graphql/mutations/CreateItem.generated';
@@ -95,16 +113,19 @@ import { useCreateItemMutation } from 'graphql/mutations/CreateItem.generated';
 const CreateItemForm = () => {
   const [createItem, { loading }] = useCreateItemMutation({
     // Success handling
+    // 成功處理
     onCompleted: (data) => {
       toast.success({ title: 'Item created' });
       navigation.goBack();
     },
     // ERROR HANDLING IS REQUIRED
+    // 錯誤處理是必要的
     onError: (error) => {
       console.error('createItem failed:', error);
       toast.error({ title: 'Failed to create item' });
     },
     // Cache update
+    // 快取更新
     update: (cache, { data }) => {
       if (data?.createItem) {
         cache.modify({
@@ -129,16 +150,24 @@ const CreateItemForm = () => {
 ```
 
 ## Mutation UI Requirements
+## 變更 UI 要求
 
 **CRITICAL: Every mutation trigger must:**
 
+**關鍵：每個變更觸發器必須：**
+
 1. **Be disabled during mutation** - Prevent double-clicks
+1. **在變更期間停用** - 防止雙擊
 2. **Show loading state** - Visual feedback
+2. **顯示載入狀態** - 視覺回饋
 3. **Have onError handler** - User knows it failed
+3. **有 onError 處理器** - 使用者知道失敗了
 4. **Show success feedback** - User knows it worked
+4. **顯示成功回饋** - 使用者知道成功了
 
 ```typescript
 // CORRECT - Complete mutation pattern
+// 正確 - 完整的變更模式
 const [submit, { loading }] = useSubmitMutation({
   onError: (error) => {
     console.error('submit failed:', error);
@@ -159,39 +188,53 @@ const [submit, { loading }] = useSubmitMutation({
 ```
 
 ## Query Options
+## 查詢選項
 
 ### Fetch Policies
+### 取得策略
 
 | Policy | Use When |
 |--------|----------|
 | `cache-first` | Data rarely changes |
+| `cache-first` | 資料很少改變 |
 | `cache-and-network` | Want fast + fresh (default) |
+| `cache-and-network` | 想要快速 + 新鮮（預設）|
 | `network-only` | Always need latest |
+| `network-only` | 總是需要最新的 |
 | `no-cache` | Never cache (rare) |
+| `no-cache` | 永不快取（罕見）|
 
 ### Common Options
+### 常見選項
 
 ```typescript
 useGetItemsQuery({
   variables: { id: itemId },
 
   // Fetch strategy
+  // 取得策略
   fetchPolicy: 'cache-and-network',
 
   // Re-render on network status changes
+  // 網路狀態變更時重新渲染
   notifyOnNetworkStatusChange: true,
 
   // Skip if condition not met
+  // 如果條件未滿足則跳過
   skip: !itemId,
 
   // Poll for updates
+  // 輪詢更新
   pollInterval: 30000,
 });
 ```
 
 ## Optimistic Updates
+## 樂觀更新
 
 For instant UI feedback:
+
+用於即時 UI 回饋：
 
 ```typescript
 const [toggleFavorite] = useToggleFavoriteMutation({
@@ -204,6 +247,7 @@ const [toggleFavorite] = useToggleFavoriteMutation({
   },
   onError: (error) => {
     // Rollback happens automatically
+    // 回滾自動發生
     console.error('toggleFavorite failed:', error);
     toast.error({ title: 'Failed to update' });
   },
@@ -211,15 +255,23 @@ const [toggleFavorite] = useToggleFavoriteMutation({
 ```
 
 ### When NOT to Use Optimistic Updates
+### 何時不使用樂觀更新
 
 - Operations that can fail validation
+- 可能無法通過驗證的操作
 - Operations with server-generated values
+- 具有伺服器生成值的操作
 - Destructive operations (delete)
+- 破壞性操作（刪除）
 - Operations affecting other users
+- 影響其他使用者的操作
 
 ## Fragments
+## 片段
 
 For reusable field selections:
+
+用於可重複使用的欄位選擇：
 
 ```graphql
 # src/graphql/fragments/ItemFields.gql
@@ -234,6 +286,8 @@ fragment ItemFields on Item {
 
 Use in queries:
 
+在查詢中使用：
+
 ```graphql
 query GetItems {
   items {
@@ -243,21 +297,26 @@ query GetItems {
 ```
 
 ## Anti-Patterns
+## 反模式
 
 ```typescript
 // WRONG - Inline gql
+// 錯誤 - 內聯 gql
 const GET_ITEMS = gql`
   query GetItems { items { id } }
 `;
 
 // CORRECT - Use .gql file + generated hook
+// 正確 - 使用 .gql 檔案 + 生成的 hook
 import { useGetItemsQuery } from './GetItems.generated';
 
 
 // WRONG - No error handler
+// 錯誤 - 沒有錯誤處理器
 const [mutate] = useMutation(MUTATION);
 
 // CORRECT - Always handle errors
+// 正確 - 總是處理錯誤
 const [mutate] = useMutation(MUTATION, {
   onError: (error) => {
     console.error('mutation failed:', error);
@@ -267,26 +326,35 @@ const [mutate] = useMutation(MUTATION, {
 
 
 // WRONG - Button not disabled during mutation
+// 錯誤 - 變更期間按鈕未停用
 <Button onPress={submit}>Submit</Button>
 
 // CORRECT - Disabled and loading
+// 正確 - 停用並載入
 <Button onPress={submit} isDisabled={loading} isLoading={loading}>
   Submit
 </Button>
 ```
 
 ## Codegen Commands
+## Codegen 指令
 
 ```bash
 # Generate types from .gql files
+# 從 .gql 檔案生成類型
 npm run gql:typegen
 
 # Download schema + generate types
+# 下載 schema + 生成類型
 npm run sync-types
 ```
 
 ## Integration with Other Skills
+## 與其他技能的整合
 
 - **react-ui-patterns**: Loading/error/empty states for queries
+- **react-ui-patterns**：查詢的載入/錯誤/空白狀態
 - **testing-patterns**: Mock generated hooks in tests
+- **testing-patterns**：在測試中模擬生成的 hooks
 - **formik-patterns**: Mutation submission patterns
+- **formik-patterns**：變更提交模式

--- a/.claude/skills/react-ui-patterns/SKILL.md
+++ b/.claude/skills/react-ui-patterns/SKILL.md
@@ -4,23 +4,35 @@ description: Modern React UI patterns for loading states, error handling, and da
 ---
 
 # React UI Patterns
+# React UI 模式
 
 ## Core Principles
+## 核心原則
 
 1. **Never show stale UI** - Loading spinners only when actually loading
+1. **永不顯示過時的 UI** - 只在實際載入時顯示載入旋轉器
 2. **Always surface errors** - Users must know when something fails
+2. **總是顯示錯誤** - 使用者必須知道何時發生失敗
 3. **Optimistic updates** - Make the UI feel instant
+3. **樂觀更新** - 讓 UI 感覺即時
 4. **Progressive disclosure** - Show content as it becomes available
+4. **漸進式揭露** - 當內容可用時顯示
 5. **Graceful degradation** - Partial data is better than no data
+5. **優雅降級** - 部分資料勝過沒有資料
 
 ## Loading State Patterns
+## 載入狀態模式
 
 ### The Golden Rule
+### 黃金法則
 
 **Show loading indicator ONLY when there's no data to display.**
 
+**只在沒有資料可顯示時顯示載入指示器。**
+
 ```typescript
 // CORRECT - Only show loading when no data exists
+// 正確 - 只在沒有資料存在時顯示載入
 const { data, loading, error } = useGetItemsQuery();
 
 if (error) return <ErrorState error={error} onRetry={refetch} />;
@@ -32,52 +44,80 @@ return <ItemList items={data.items} />;
 
 ```typescript
 // WRONG - Shows spinner even when we have cached data
+// 錯誤 - 即使有快取資料也顯示旋轉器
 if (loading) return <LoadingState />; // Flashes on refetch!
+                                      // 重新取得時會閃爍！
 ```
 
 ### Loading State Decision Tree
+### 載入狀態決策樹
 
 ```
 Is there an error?
+有錯誤嗎？
   → Yes: Show error state with retry option
+  → 是：顯示錯誤狀態並提供重試選項
   → No: Continue
+  → 否：繼續
 
 Is it loading AND we have no data?
+正在載入且沒有資料嗎？
   → Yes: Show loading indicator (spinner/skeleton)
+  → 是：顯示載入指示器（旋轉器/骨架）
   → No: Continue
+  → 否：繼續
 
 Do we have data?
+有資料嗎？
   → Yes, with items: Show the data
+  → 是，有項目：顯示資料
   → Yes, but empty: Show empty state
+  → 是，但為空：顯示空白狀態
   → No: Show loading (fallback)
+  → 否：顯示載入（後備）
 ```
 
 ### Skeleton vs Spinner
+### 骨架 vs 旋轉器
 
 | Use Skeleton When | Use Spinner When |
 |-------------------|------------------|
 | Known content shape | Unknown content shape |
+| 已知內容形狀 | 未知內容形狀 |
 | List/card layouts | Modal actions |
+| 列表/卡片佈局 | 模態框操作 |
 | Initial page load | Button submissions |
+| 初始頁面載入 | 按鈕提交 |
 | Content placeholders | Inline operations |
+| 內容佔位符 | 內聯操作 |
 
 ## Error Handling Patterns
+## 錯誤處理模式
 
 ### The Error Handling Hierarchy
+### 錯誤處理層次結構
 
 ```
 1. Inline error (field-level) → Form validation errors
+1. 內聯錯誤（欄位級別）→ 表單驗證錯誤
 2. Toast notification → Recoverable errors, user can retry
+2. Toast 通知 → 可恢復的錯誤，使用者可以重試
 3. Error banner → Page-level errors, data still partially usable
+3. 錯誤橫幅 → 頁面級別錯誤，資料仍部分可用
 4. Full error screen → Unrecoverable, needs user action
+4. 完整錯誤畫面 → 無法恢復，需要使用者操作
 ```
 
 ### Always Show Errors
+### 總是顯示錯誤
 
 **CRITICAL: Never swallow errors silently.**
 
+**關鍵：永遠不要靜默吞噬錯誤。**
+
 ```typescript
 // CORRECT - Error always surfaced to user
+// 正確 - 錯誤總是顯示給使用者
 const [createItem, { loading }] = useCreateItemMutation({
   onCompleted: () => {
     toast.success({ title: 'Item created' });
@@ -89,14 +129,17 @@ const [createItem, { loading }] = useCreateItemMutation({
 });
 
 // WRONG - Error silently caught, user has no idea
+// 錯誤 - 錯誤被靜默捕獲，使用者不知道
 const [createItem] = useCreateItemMutation({
   onError: (error) => {
     console.error(error); // User sees nothing!
+                          // 使用者什麼都看不到！
   },
 });
 ```
 
 ### Error State Component Pattern
+### 錯誤狀態元件模式
 
 ```typescript
 interface ErrorStateProps {
@@ -118,8 +161,10 @@ const ErrorState = ({ error, onRetry, title }: ErrorStateProps) => (
 ```
 
 ## Button State Patterns
+## 按鈕狀態模式
 
 ### Button Loading State
+### 按鈕載入狀態
 
 ```tsx
 <Button
@@ -132,11 +177,15 @@ const ErrorState = ({ error, onRetry, title }: ErrorStateProps) => (
 ```
 
 ### Disable During Operations
+### 操作期間停用
 
 **CRITICAL: Always disable triggers during async operations.**
 
+**關鍵：在非同步操作期間總是停用觸發器。**
+
 ```tsx
 // CORRECT - Button disabled while loading
+// 正確 - 載入時按鈕停用
 <Button
   disabled={isSubmitting}
   isLoading={isSubmitting}
@@ -146,22 +195,29 @@ const ErrorState = ({ error, onRetry, title }: ErrorStateProps) => (
 </Button>
 
 // WRONG - User can tap multiple times
+// 錯誤 - 使用者可以點擊多次
 <Button onClick={handleSubmit}>
   {isSubmitting ? 'Submitting...' : 'Submit'}
 </Button>
 ```
 
 ## Empty States
+## 空白狀態
 
 ### Empty State Requirements
+### 空白狀態要求
 
 Every list/collection MUST have an empty state:
 
+每個列表/集合都必須有空白狀態：
+
 ```tsx
 // WRONG - No empty state
+// 錯誤 - 沒有空白狀態
 return <FlatList data={items} />;
 
 // CORRECT - Explicit empty state
+// 正確 - 明確的空白狀態
 return (
   <FlatList
     data={items}
@@ -171,9 +227,11 @@ return (
 ```
 
 ### Contextual Empty States
+### 情境式空白狀態
 
 ```tsx
 // Search with no results
+// 搜尋無結果
 <EmptyState
   icon="search"
   title="No results found"
@@ -181,6 +239,7 @@ return (
 />
 
 // List with no items yet
+// 列表尚無項目
 <EmptyState
   icon="plus-circle"
   title="No items yet"
@@ -190,6 +249,7 @@ return (
 ```
 
 ## Form Submission Pattern
+## 表單提交模式
 
 ```tsx
 const MyForm = () => {
@@ -227,28 +287,36 @@ const MyForm = () => {
 ```
 
 ## Anti-Patterns
+## 反模式
 
 ### Loading States
+### 載入狀態
 
 ```typescript
 // WRONG - Spinner when data exists (causes flash)
+// 錯誤 - 資料存在時顯示旋轉器（造成閃爍）
 if (loading) return <Spinner />;
 
 // CORRECT - Only show loading without data
+// 正確 - 只在沒有資料時顯示載入
 if (loading && !data) return <Spinner />;
 ```
 
 ### Error Handling
+### 錯誤處理
 
 ```typescript
 // WRONG - Error swallowed
+// 錯誤 - 錯誤被吞噬
 try {
   await mutation();
 } catch (e) {
   console.log(e); // User has no idea!
+                  // 使用者不知道！
 }
 
 // CORRECT - Error surfaced
+// 正確 - 錯誤被顯示
 onError: (error) => {
   console.error('operation failed:', error);
   toast.error({ title: 'Operation failed' });
@@ -256,34 +324,53 @@ onError: (error) => {
 ```
 
 ### Button States
+### 按鈕狀態
 
 ```typescript
 // WRONG - Button not disabled during submission
+// 錯誤 - 提交期間按鈕未停用
 <Button onClick={submit}>Submit</Button>
 
 // CORRECT - Disabled and shows loading
+// 正確 - 停用並顯示載入
 <Button onClick={submit} disabled={loading} isLoading={loading}>
   Submit
 </Button>
 ```
 
 ## Checklist
+## 檢查清單
 
 Before completing any UI component:
 
+在完成任何 UI 元件之前：
+
 **UI States:**
+**UI 狀態：**
 - [ ] Error state handled and shown to user
+- [ ] 錯誤狀態已處理並顯示給使用者
 - [ ] Loading state shown only when no data exists
+- [ ] 只在沒有資料存在時顯示載入狀態
 - [ ] Empty state provided for collections
+- [ ] 為集合提供空白狀態
 - [ ] Buttons disabled during async operations
+- [ ] 非同步操作期間按鈕停用
 - [ ] Buttons show loading indicator when appropriate
+- [ ] 適當時按鈕顯示載入指示器
 
 **Data & Mutations:**
+**資料與變更：**
 - [ ] Mutations have onError handler
+- [ ] 變更有 onError 處理器
 - [ ] All user actions have feedback (toast/visual)
+- [ ] 所有使用者操作都有回饋（toast/視覺）
 
 ## Integration with Other Skills
+## 與其他技能的整合
 
 - **graphql-schema**: Use mutation patterns with proper error handling
+- **graphql-schema**：使用具有適當錯誤處理的變更模式
 - **testing-patterns**: Test all UI states (loading, error, empty, success)
+- **testing-patterns**：測試所有 UI 狀態（載入、錯誤、空白、成功）
 - **formik-patterns**: Apply form submission patterns
+- **formik-patterns**：應用表單提交模式

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -4,147 +4,252 @@ description: Four-phase debugging methodology with root cause analysis. Use when
 ---
 
 # Systematic Debugging
+# 系統化除錯
 
 ## Core Principle
+## 核心原則
 
 **NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
 
+**沒有根本原因調查就不要修復。**
+
 Never apply symptom-focused patches that mask underlying problems. Understand WHY something fails before attempting to fix it.
 
+永遠不要應用只針對症狀的修補程式來掩蓋底層問題。在嘗試修復之前，先理解為什麼會失敗。
+
 ## The Four-Phase Framework
+## 四階段框架
 
 ### Phase 1: Root Cause Investigation
+### 第一階段：根本原因調查
 
 Before touching any code:
 
+在觸碰任何程式碼之前：
+
 1. **Read error messages thoroughly** - Every word matters
+1. **徹底閱讀錯誤訊息** - 每個字都很重要
 2. **Reproduce the issue consistently** - If you can't reproduce it, you can't verify a fix
+2. **一致地重現問題** - 如果無法重現，就無法驗證修復
 3. **Examine recent changes** - What changed before this started failing?
+3. **檢查最近的變更** - 在開始失敗之前發生了什麼變化？
 4. **Gather diagnostic evidence** - Logs, stack traces, state dumps
+4. **收集診斷證據** - 日誌、堆疊追蹤、狀態轉儲
 5. **Trace data flow** - Follow the call chain to find where bad values originate
+5. **追蹤資料流** - 跟隨呼叫鏈找出錯誤值的來源
 
 **Root Cause Tracing Technique:**
+**根本原因追蹤技巧：**
 ```
 1. Observe the symptom - Where does the error manifest?
+1. 觀察症狀 - 錯誤在哪裡出現？
 2. Find immediate cause - Which code directly produces the error?
+2. 找出直接原因 - 哪段程式碼直接產生錯誤？
 3. Ask "What called this?" - Map the call chain upward
+3. 問「是什麼呼叫了這個？」- 向上映射呼叫鏈
 4. Keep tracing up - Follow invalid data backward through the stack
+4. 繼續向上追蹤 - 通過堆疊向後追蹤無效資料
 5. Find original trigger - Where did the problem actually start?
+5. 找出原始觸發點 - 問題實際上從哪裡開始？
 ```
 
 **Key principle:** Never fix problems solely where errors appear—always trace to the original trigger.
 
+**關鍵原則：** 永遠不要只在錯誤出現的地方修復問題——總是追蹤到原始觸發點。
+
 ### Phase 2: Pattern Analysis
+### 第二階段：模式分析
 
 1. **Locate working examples** - Find similar code that works correctly
+1. **找出正常運作的範例** - 找到運作正常的類似程式碼
 2. **Compare implementations completely** - Don't just skim
+2. **完整比較實作** - 不要只是略讀
 3. **Identify differences** - What's different between working and broken?
+3. **識別差異** - 正常和損壞的之間有什麼不同？
 4. **Understand dependencies** - What does this code depend on?
+4. **理解依賴關係** - 這段程式碼依賴什麼？
 
 ### Phase 3: Hypothesis and Testing
+### 第三階段：假設與測試
 
 Apply the scientific method:
 
+應用科學方法：
+
 1. **Formulate ONE clear hypothesis** - "The error occurs because X"
+1. **制定一個清晰的假設** -「錯誤發生是因為 X」
 2. **Design minimal test** - Change ONE variable at a time
+2. **設計最小測試** - 一次只改變一個變數
 3. **Predict the outcome** - What should happen if hypothesis is correct?
+3. **預測結果** - 如果假設正確應該會發生什麼？
 4. **Run the test** - Execute and observe
+4. **執行測試** - 執行並觀察
 5. **Verify results** - Did it behave as predicted?
+5. **驗證結果** - 是否如預測般運作？
 6. **Iterate or proceed** - Refine hypothesis if wrong, implement if right
+6. **迭代或繼續** - 如果錯誤則改進假設，如果正確則實作
 
 ### Phase 4: Implementation
+### 第四階段：實作
 
 1. **Create failing test case** - Captures the bug behavior
+1. **建立失敗的測試案例** - 捕捉錯誤行為
 2. **Implement single fix** - Address root cause, not symptoms
+2. **實作單一修復** - 解決根本原因，而非症狀
 3. **Verify test passes** - Confirms fix works
+3. **驗證測試通過** - 確認修復有效
 4. **Run full test suite** - Ensure no regressions
+4. **執行完整測試套件** - 確保沒有退化
 5. **If fix fails, STOP** - Re-evaluate hypothesis
+5. **如果修復失敗，停止** - 重新評估假設
 
 **Critical rule:** If THREE or more fixes fail consecutively, STOP. This signals architectural problems requiring discussion, not more patches.
 
+**關鍵規則：** 如果連續三次或更多修復失敗，請停止。這表示架構問題需要討論，而不是更多修補程式。
+
 ## Red Flags - Process Violations
+## 紅旗警告 - 流程違規
 
 Stop immediately if you catch yourself thinking:
 
+如果你發現自己在想以下想法，請立即停止：
+
 - "Quick fix for now, investigate later"
+-「現在快速修復，稍後再調查」
 - "One more fix attempt" (after multiple failures)
+-「再嘗試修復一次」（在多次失敗之後）
 - "This should work" (without understanding why)
+-「這應該可以運作」（不理解為什麼）
 - "Let me just try..." (without hypothesis)
+-「讓我試試看...」（沒有假設）
 - "It works on my machine" (without investigating difference)
+-「在我的機器上可以運作」（不調查差異）
 
 ## Warning Signs of Deeper Problems
+## 更深層問題的警告信號
 
 **Consecutive fixes revealing new problems in different areas** indicates architectural issues:
 
+**連續修復揭示不同領域的新問題** 表示架構問題：
+
 - Stop patching
+- 停止修補
 - Document what you've found
+- 記錄你發現的內容
 - Discuss with team before proceeding
+- 在繼續之前與團隊討論
 - Consider if the design needs rethinking
+- 考慮是否需要重新思考設計
 
 ## Common Debugging Scenarios
+## 常見除錯場景
 
 ### Test Failures
+### 測試失敗
 
 ```
 1. Read the FULL error message and stack trace
+1. 閱讀完整的錯誤訊息和堆疊追蹤
 2. Identify which assertion failed and why
+2. 識別哪個斷言失敗以及為什麼
 3. Check test setup - is the test environment correct?
+3. 檢查測試設置 - 測試環境是否正確？
 4. Check test data - are mocks/fixtures correct?
+4. 檢查測試資料 - 模擬/固定裝置是否正確？
 5. Trace to the source of unexpected value
+5. 追蹤到意外值的來源
 ```
 
 ### Runtime Errors
+### 執行時期錯誤
 
 ```
 1. Capture the full stack trace
+1. 捕捉完整的堆疊追蹤
 2. Identify the line that throws
+2. 識別拋出錯誤的行
 3. Check what values are undefined/null
+3. 檢查哪些值是 undefined/null
 4. Trace backward to find where bad value originated
+4. 向後追蹤找出錯誤值的來源
 5. Add validation at the source
+5. 在來源處加入驗證
 ```
 
 ### "It worked before"
+###「之前可以運作」
 
 ```
 1. Use git bisect to find the breaking commit
+1. 使用 git bisect 找出破壞性的提交
 2. Compare the change with previous working version
+2. 將變更與先前的工作版本比較
 3. Identify what assumption changed
+3. 識別哪個假設改變了
 4. Fix at the source of the assumption violation
+4. 在假設違反的來源處修復
 ```
 
 ### Intermittent Failures
+### 間歇性失敗
 
 ```
 1. Look for race conditions
+1. 尋找競態條件
 2. Check for shared mutable state
+2. 檢查共享的可變狀態
 3. Examine async operation ordering
+3. 檢查非同步操作順序
 4. Look for timing dependencies
+4. 尋找時間依賴
 5. Add deterministic waits or proper synchronization
+5. 加入確定性等待或適當的同步化
 ```
 
 ## Debugging Checklist
+## 除錯檢查清單
 
 Before claiming a bug is fixed:
 
+在聲稱錯誤已修復之前：
+
 - [ ] Root cause identified and documented
+- [ ] 根本原因已識別並記錄
 - [ ] Hypothesis formed and tested
+- [ ] 假設已形成並測試
 - [ ] Fix addresses root cause, not symptoms
+- [ ] 修復解決根本原因，而非症狀
 - [ ] Failing test created that reproduces bug
+- [ ] 建立了能重現錯誤的失敗測試
 - [ ] Test now passes with fix
+- [ ] 測試現在通過修復
 - [ ] Full test suite passes
+- [ ] 完整測試套件通過
 - [ ] No "quick fix" rationalization used
+- [ ] 沒有使用「快速修復」的合理化藉口
 - [ ] Fix is minimal and focused
+- [ ] 修復是最小且專注的
 
 ## Success Metrics
+## 成功指標
 
 Systematic debugging achieves ~95% first-time fix rate vs ~40% with ad-hoc approaches.
 
+系統化除錯達到約 95% 的首次修復率，相對於臨時方法的約 40%。
+
 Signs you're doing it right:
+你做對了的跡象：
 - Fixes don't create new bugs
+- 修復不會產生新的錯誤
 - You can explain WHY the bug occurred
+- 你可以解釋為什麼會發生錯誤
 - Similar bugs don't recur
+- 類似的錯誤不會再次發生
 - Code is better after the fix, not just "working"
+- 修復後的程式碼更好，而不僅僅是「可運作」
 
 ## Integration with Other Skills
+## 與其他技能的整合
 
 - **testing-patterns**: Create test that reproduces the bug before fixing
+- **testing-patterns**：在修復之前建立能重現錯誤的測試

--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -4,32 +4,53 @@ description: Jest testing patterns, factory functions, mocking strategies, and T
 ---
 
 # Testing Patterns and Utilities
+# 測試模式與工具
 
 ## Testing Philosophy
+## 測試哲學
 
 **Test-Driven Development (TDD):**
+**測試驅動開發 (TDD)：**
 - Write failing test FIRST
+- 先編寫失敗的測試
 - Implement minimal code to pass
+- 實作最少的程式碼以通過測試
 - Refactor after green
+- 測試通過後進行重構
 - Never write production code without a failing test
+- 永遠不要在沒有失敗測試的情況下編寫正式程式碼
 
 **Behavior-Driven Testing:**
+**行為驅動測試：**
 - Test behavior, not implementation
+- 測試行為，而非實作
 - Focus on public APIs and business requirements
+- 專注於公開 API 和業務需求
 - Avoid testing implementation details
+- 避免測試實作細節
 - Use descriptive test names that describe behavior
+- 使用描述行為的測試名稱
 
 **Factory Pattern:**
+**工廠模式：**
 - Create `getMockX(overrides?: Partial<X>)` functions
+- 建立 `getMockX(overrides?: Partial<X>)` 函數
 - Provide sensible defaults
+- 提供合理的預設值
 - Allow overriding specific properties
+- 允許覆蓋特定屬性
 - Keep tests DRY and maintainable
+- 保持測試乾淨且易於維護
 
 ## Test Utilities
+## 測試工具
 
 ### Custom Render Function
+### 自訂渲染函數
 
 Create a custom render that wraps components with required providers:
+
+建立一個自訂渲染函數，將元件包裝在必要的 provider 中：
 
 ```typescript
 // src/utils/testUtils.tsx
@@ -44,6 +65,7 @@ export const renderWithTheme = (ui: React.ReactElement) => {
 ```
 
 **Usage:**
+**使用方式：**
 ```typescript
 import { renderWithTheme } from 'utils/testUtils';
 import { screen } from '@testing-library/react-native';
@@ -55,8 +77,10 @@ it('should render component', () => {
 ```
 
 ## Factory Pattern
+## 工廠模式
 
 ### Component Props Factory
+### 元件屬性工廠
 
 ```typescript
 import { ComponentProps } from 'react';
@@ -74,6 +98,7 @@ const getMockMyComponentProps = (
 };
 
 // Usage in tests
+// 在測試中使用
 it('should render with custom title', () => {
   const props = getMockMyComponentProps({ title: 'Custom Title' });
   renderWithTheme(<MyComponent {...props} />);
@@ -82,6 +107,7 @@ it('should render with custom title', () => {
 ```
 
 ### Data Factory
+### 資料工廠
 
 ```typescript
 interface User {
@@ -102,6 +128,7 @@ const getMockUser = (overrides?: Partial<User>): User => {
 };
 
 // Usage
+// 使用方式
 it('should display admin badge for admin users', () => {
   const user = getMockUser({ role: 'admin' });
   renderWithTheme(<UserCard user={user} />);
@@ -110,14 +137,18 @@ it('should display admin badge for admin users', () => {
 ```
 
 ## Mocking Patterns
+## 模擬模式
 
 ### Mocking Modules
+### 模擬模組
 
 ```typescript
 // Mock entire module
+// 模擬整個模組
 jest.mock('utils/analytics');
 
 // Mock with factory function
+// 使用工廠函數模擬
 jest.mock('utils/analytics', () => ({
   Analytics: {
     logEvent: jest.fn(),
@@ -125,10 +156,12 @@ jest.mock('utils/analytics', () => ({
 }));
 
 // Access mock in test
+// 在測試中存取模擬物件
 const mockLogEvent = jest.requireMock('utils/analytics').Analytics.logEvent;
 ```
 
 ### Mocking GraphQL Hooks
+### 模擬 GraphQL Hooks
 
 ```typescript
 jest.mock('./GetItems.generated', () => ({
@@ -140,6 +173,7 @@ const mockUseGetItemsQuery = jest.requireMock(
 ).useGetItemsQuery as jest.Mock;
 
 // In test
+// 在測試中
 mockUseGetItemsQuery.mockReturnValue({
   data: { items: [] },
   loading: false,
@@ -148,6 +182,7 @@ mockUseGetItemsQuery.mockReturnValue({
 ```
 
 ## Test Structure
+## 測試結構
 
 ```typescript
 describe('ComponentName', () => {
@@ -171,21 +206,26 @@ describe('ComponentName', () => {
 ```
 
 ## Query Patterns
+## 查詢模式
 
 ```typescript
 // Element must exist
+// 元素必須存在
 expect(screen.getByText('Hello')).toBeTruthy();
 
 // Element should not exist
+// 元素不應存在
 expect(screen.queryByText('Goodbye')).toBeNull();
 
 // Element appears asynchronously
+// 元素非同步出現
 await waitFor(() => {
   expect(screen.findByText('Loaded')).toBeTruthy();
 });
 ```
 
 ## User Interaction Patterns
+## 使用者互動模式
 
 ```typescript
 import { fireEvent, screen } from '@testing-library/react-native';
@@ -205,55 +245,77 @@ it('should submit form on button click', async () => {
 ```
 
 ## Anti-Patterns to Avoid
+## 應避免的反模式
 
 ### Testing Mock Behavior Instead of Real Behavior
+### 測試模擬行為而非真實行為
 
 ```typescript
 // Bad - testing the mock
+// 不好 - 測試模擬物件
 expect(mockFetchData).toHaveBeenCalled();
 
 // Good - testing actual behavior
+// 好 - 測試實際行為
 expect(screen.getByText('John Doe')).toBeTruthy();
 ```
 
 ### Not Using Factories
+### 不使用工廠函數
 
 ```typescript
 // Bad - duplicated, inconsistent test data
+// 不好 - 重複且不一致的測試資料
 it('test 1', () => {
   const user = { id: '1', name: 'John', email: 'john@test.com', role: 'user' };
 });
 it('test 2', () => {
   const user = { id: '2', name: 'Jane', email: 'jane@test.com' }; // Missing role!
+                                                                   // 缺少 role！
 });
 
 // Good - reusable factory
+// 好 - 可重複使用的工廠函數
 const user = getMockUser({ name: 'Custom Name' });
 ```
 
 ## Best Practices
+## 最佳實踐
 
 1. **Always use factory functions** for props and data
+1. **總是使用工廠函數** 來建立屬性和資料
 2. **Test behavior, not implementation**
+2. **測試行為，而非實作**
 3. **Use descriptive test names**
+3. **使用描述性的測試名稱**
 4. **Organize with describe blocks**
+4. **使用 describe 區塊組織測試**
 5. **Clear mocks between tests**
+5. **在測試之間清除模擬物件**
 6. **Keep tests focused** - one behavior per test
+6. **保持測試專注** - 每個測試一個行為
 
 ## Running Tests
+## 執行測試
 
 ```bash
 # Run all tests
+# 執行所有測試
 npm test
 
 # Run with coverage
+# 執行並產生覆蓋率報告
 npm run test:coverage
 
 # Run specific file
+# 執行特定檔案
 npm test ComponentName.test.tsx
 ```
 
 ## Integration with Other Skills
+## 與其他技能的整合
 
 - **react-ui-patterns**: Test all UI states (loading, error, empty, success)
+- **react-ui-patterns**：測試所有 UI 狀態（載入、錯誤、空白、成功）
 - **systematic-debugging**: Write test that reproduces bug before fixing
+- **systematic-debugging**：在修復之前編寫能重現錯誤的測試

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -1,23 +1,37 @@
-name: PR - Claude Code Review
+name: PR - Claude Code Review / PR - Claude Code 審查
+
+# 工作流程描述：當 PR 被建立、更新或有評論提及 @claude 時自動執行代碼審查
+# Workflow Description: Automatically runs code review when PR is created, updated, or when @claude is mentioned in comments
 
 on:
   pull_request:
+    # 觸發類型：PR 開啟、同步（新提交）、重新開啟
+    # Trigger types: PR opened, synchronized (new commits), reopened
     types: [opened, synchronize, reopened]
   issue_comment:
+    # 觸發類型：評論建立
+    # Trigger types: Comment created
     types: [created]
 
 concurrency:
+  # 並發控制：同一 PR 的工作流程會取消正在進行的運行
+  # Concurrency control: Cancels in-progress runs for the same PR
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: write
-  issues: read
+  # 權限設定
+  # Permissions configuration
+  contents: read          # 讀取倉庫內容 / Read repository contents
+  pull-requests: write    # 寫入 PR 評論 / Write PR comments
+  issues: read            # 讀取 issue 資訊 / Read issue information
 
 jobs:
   review:
-    # Run on PR events, or on issue comments that mention @claude
+    # 任務：執行代碼審查
+    # Job: Execute code review
+    # 運行條件：在 PR 事件時運行，或在包含 @claude 的 issue 評論時運行
+    # Run condition: Run on PR events, or on issue comments that mention @claude
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
@@ -25,26 +39,34 @@ jobs:
        contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository (PR event)
+      - name: Checkout repository (PR event) / 檢出倉庫（PR 事件）
+        # 條件：僅在 PR 事件時執行
+        # Condition: Only run on PR events
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Checkout repository (issue_comment event)
+      - name: Checkout repository (issue_comment event) / 檢出倉庫（issue_comment 事件）
+        # 條件：僅在評論事件時執行
+        # Condition: Only run on comment events
         if: github.event_name == 'issue_comment'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Checkout PR branch (issue_comment event)
+      - name: Checkout PR branch (issue_comment event) / 檢出 PR 分支（issue_comment 事件）
+        # 步驟說明：切換到 PR 對應的分支
+        # Step description: Switch to the PR branch
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr checkout ${{ github.event.issue.number }}
 
-      - name: Get PR base branch
+      - name: Get PR base branch / 獲取 PR 基礎分支
+        # 步驟說明：獲取 PR 的目標基礎分支名稱
+        # Step description: Get the target base branch name of the PR
         id: pr-info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +78,9 @@ jobs:
             echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
           fi
 
-      - name: Claude Code Review
+      - name: Claude Code Review / Claude 代碼審查
+        # 步驟說明：使用 Claude 執行代碼審查
+        # Step description: Execute code review using Claude
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -65,11 +89,16 @@ jobs:
           track_progress: true
           prompt: |
             Review this Pull Request using the standards in .claude/agents/code-reviewer.md
+            根據 .claude/agents/code-reviewer.md 中的標準審查此 Pull Request
 
             1. Read .claude/agents/code-reviewer.md for the full checklist
+               閱讀 .claude/agents/code-reviewer.md 獲取完整的檢查清單
             2. Run `git diff origin/${{ steps.pr-info.outputs.base_ref }}...HEAD` to see changes
+               運行 `git diff origin/${{ steps.pr-info.outputs.base_ref }}...HEAD` 查看變更
             3. Apply the review checklist to modified files
+               將審查檢查清單應用於修改的文件
             4. Provide feedback organized by severity (Critical, Warning, Suggestion)
+               按嚴重程度（關鍵、警告、建議）提供反饋
           claude_args: |
             --max-turns 10
             --allowedTools "Read,Glob,Grep,Bash(git:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/scheduled-claude-code-dependency-audit.yml
+++ b/.github/workflows/scheduled-claude-code-dependency-audit.yml
@@ -1,38 +1,52 @@
-name: Scheduled - Dependency Audit
+name: Scheduled - Dependency Audit / 定期 - 依賴審計
+
+# 工作流程描述：定期檢查和更新過時的依賴及安全漏洞
+# Workflow Description: Periodically checks and updates outdated dependencies and security vulnerabilities
 
 on:
   schedule:
-    # Run every 2 weeks (1st and 15th of each month) at 10 AM UTC
+    # 運行時間：每兩週（每月 1 號和 15 號）上午 10 點（UTC）
+    # Run time: Every 2 weeks (1st and 15th of each month) at 10 AM UTC
     - cron: '0 10 1,15 * *'
   workflow_dispatch:
+    # 手動觸發
+    # Manual trigger
 
 concurrency:
+  # 並發控制：同一分支的工作流程會取消正在進行的運行
+  # Concurrency control: Cancels in-progress runs for the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  # 權限設定
+  # Permissions configuration
+  contents: write        # 寫入倉庫內容 / Write repository contents
+  pull-requests: write   # 創建 PR / Create PRs
 
 jobs:
   dependency-audit:
+    # 任務：依賴審計
+    # Job: Dependency audit
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository / 檢出倉庫
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
+      - name: Setup Node.js / 設置 Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Install dependencies / 安裝依賴
         run: npm ci
 
-      - name: Check for outdated dependencies
+      - name: Check for outdated dependencies / 檢查過時的依賴
+        # 步驟說明：檢查是否有過時的 npm 套件
+        # Step description: Check if there are outdated npm packages
         id: check-outdated
         run: |
           echo "Checking for outdated dependencies..."
@@ -47,7 +61,9 @@ jobs:
             cat /tmp/outdated.json
           fi
 
-      - name: Run security audit
+      - name: Run security audit / 運行安全審計
+        # 步驟說明：運行 npm audit 檢查安全漏洞
+        # Step description: Run npm audit to check for security vulnerabilities
         id: security-audit
         run: |
           echo "Running security audit..."
@@ -61,7 +77,9 @@ jobs:
             echo "vulnerabilities=0" >> $GITHUB_OUTPUT
           fi
 
-      - name: Claude Dependency Analysis & Update
+      - name: Claude Dependency Analysis & Update / Claude 依賴分析與更新
+        # 條件：僅在有過時依賴或安全漏洞時執行
+        # Condition: Only run when there are outdated dependencies or security vulnerabilities
         if: steps.check-outdated.outputs.has_outdated == 'true' || steps.security-audit.outputs.vulnerabilities != '0'
         uses: anthropics/claude-code-action@beta
         with:
@@ -72,44 +90,62 @@ jobs:
           branch_prefix: claude/deps-update-
           track_progress: true
           prompt: |
-            # Dependency Audit
+            # Dependency Audit / 依賴審計
 
             You are running a scheduled dependency audit.
+            你正在執行定期依賴審計。
 
-            ## Your Tasks
+            ## Your Tasks / 你的任務
 
-            1. **Analyze outdated packages**: Run `npm outdated` and review results
+            1. **Analyze outdated packages / 分析過時的套件**: Run `npm outdated` and review results
+               運行 `npm outdated` 並審查結果
 
-            2. **Analyze security vulnerabilities**: Run `npm audit` and review results
+            2. **Analyze security vulnerabilities / 分析安全漏洞**: Run `npm audit` and review results
+               運行 `npm audit` 並審查結果
 
-            3. **Update packages safely**:
+            3. **Update packages safely / 安全地更新套件**:
                - Use `npm update {package}` for minor/patch updates
+                 對於小版本/補丁更新使用 `npm update {package}`
                - For major versions, use `npm install {package}@latest` only if safe
+                 對於主版本更新，僅在安全時使用 `npm install {package}@latest`
                - Run `npm audit fix` for security fixes
+                 運行 `npm audit fix` 修復安全問題
 
-            4. **Verify updates**:
+            4. **Verify updates / 驗證更新**:
                - Run `npm run lint` to check for issues
+                 運行 `npm run lint` 檢查問題
                - Run `npm test` to verify tests pass
+                 運行 `npm test` 驗證測試通過
                - If anything fails, revert that specific update
+                 如果有任何失敗，還原該特定更新
 
-            5. **Create PR** if any updates were made:
-               - Create branch from main
+            5. **Create PR / 創建 PR** if any updates were made:
+               如果有任何更新：
+               - Create branch from main / 從 main 創建分支
                - Commit package.json and package-lock.json changes
+                 提交 package.json 和 package-lock.json 變更
                - PR title: "chore(deps): update dependencies"
-               - PR body should list:
+               - PR body should list / PR 正文應列出:
                  - Each package updated with old → new version
+                   每個更新的套件及其舊版本 → 新版本
                  - Security vulnerabilities fixed (if any)
+                   修復的安全漏洞（如有）
 
-            ## Guidelines
+            ## Guidelines / 指南
             - Be CONSERVATIVE - when in doubt, don't update
+              保守行事 - 如有疑問，不要更新
             - If tests fail after an update, revert that update
-            - Group related updates together
+              如果更新後測試失敗，還原該更新
+            - Group related updates together / 將相關更新分組
             - If NO updates are possible, report that and don't create a PR
+              如果無法更新，報告並不要創建 PR
           claude_args: |
             --max-turns 40
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*)"
 
-      - name: Report no updates needed
+      - name: Report no updates needed / 報告不需要更新
+        # 條件：沒有過時依賴且無安全漏洞時執行
+        # Condition: Run when there are no outdated dependencies and no security vulnerabilities
         if: steps.check-outdated.outputs.has_outdated == 'false' && steps.security-audit.outputs.vulnerabilities == '0'
         run: |
           echo "All dependencies are up to date and no security vulnerabilities found."

--- a/.github/workflows/scheduled-claude-code-docs-sync.yml
+++ b/.github/workflows/scheduled-claude-code-docs-sync.yml
@@ -1,34 +1,48 @@
-name: Scheduled - Documentation Sync
+name: Scheduled - Documentation Sync / 定期 - 文檔同步
+
+# 工作流程描述：定期檢查代碼變更並同步更新文檔
+# Workflow Description: Periodically checks code changes and syncs documentation updates
 
 on:
   schedule:
-    # Run on the 1st of every month at 9 AM UTC
+    # 運行時間：每月 1 號上午 9 點（UTC）
+    # Run time: 1st of every month at 9 AM UTC
     - cron: '0 9 1 * *'
   workflow_dispatch:
+    # 手動觸發選項
+    # Manual trigger options
     inputs:
       days_back:
-        description: 'Number of days to look back for changes'
+        description: 'Number of days to look back for changes / 回溯檢查變更的天數'
         required: false
         default: '30'
 
 concurrency:
+  # 並發控制：同一分支的工作流程會取消正在進行的運行
+  # Concurrency control: Cancels in-progress runs for the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  # 權限設定
+  # Permissions configuration
+  contents: write        # 寫入倉庫內容 / Write repository contents
+  pull-requests: write   # 創建 PR / Create PRs
 
 jobs:
   docs-sync:
+    # 任務：文檔同步
+    # Job: Documentation synchronization
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository / 檢出倉庫
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Check for code changes in period
+      - name: Check for code changes in period / 檢查期間內的代碼變更
+        # 步驟說明：檢查指定天數內的代碼變更
+        # Step description: Check code changes within the specified number of days
         id: check-changes
         run: |
           DAYS_BACK="${{ github.event.inputs.days_back || '30' }}"
@@ -36,6 +50,7 @@ jobs:
 
           echo "Checking for changes since: $SINCE_DATE"
 
+          # 獲取變更的代碼文件（排除文檔本身）
           # Get changed code files (excluding docs themselves)
           CHANGED_FILES=$(git log --since="$SINCE_DATE" --name-only --pretty=format: -- \
             '*.ts' '*.tsx' '*.js' '*.jsx' \
@@ -55,7 +70,9 @@ jobs:
 
           echo "since_date=$SINCE_DATE" >> $GITHUB_OUTPUT
 
-      - name: Claude Documentation Sync
+      - name: Claude Documentation Sync / Claude 文檔同步
+        # 條件：僅在有代碼變更時執行
+        # Condition: Only run when there are code changes
         if: steps.check-changes.outputs.has_changes == 'true'
         uses: anthropics/claude-code-action@beta
         with:
@@ -66,50 +83,62 @@ jobs:
           branch_prefix: claude/docs-sync-
           track_progress: true
           prompt: |
-            # Monthly Documentation Sync
+            # Monthly Documentation Sync / 每月文檔同步
 
             You are running a scheduled documentation sync. Code has changed since ${{ steps.check-changes.outputs.since_date }}.
+            你正在執行定期文檔同步。代碼自 ${{ steps.check-changes.outputs.since_date }} 以來已有變更。
 
-            ## Changed Files
+            ## Changed Files / 變更的文件
             The following code files have been modified:
+            以下代碼文件已被修改：
             ```
             ${{ steps.check-changes.outputs.changed_files }}
             ```
 
-            ## Your Tasks
+            ## Your Tasks / 你的任務
 
-            1. **Analyze Changes**: Review the changed files to understand what functionality was added, modified, or removed.
+            1. **Analyze Changes / 分析變更**: Review the changed files to understand what functionality was added, modified, or removed.
+               審查變更的文件以了解新增、修改或移除了哪些功能。
 
-            2. **Find Related Documentation**: Search for documentation that might be affected:
-               - `/docs/` directory
-               - README.md files
-               - TSDoc comments in the code
+            2. **Find Related Documentation / 查找相關文檔**: Search for documentation that might be affected:
+               搜索可能受影響的文檔：
+               - `/docs/` directory / `/docs/` 目錄
+               - README.md files / README.md 文件
+               - TSDoc comments in the code / 代碼中的 TSDoc 註釋
 
-            3. **Check for Actual Problems**: For each code change, determine if existing docs are now WRONG:
-               - Do code examples still work?
-               - Are API signatures/types now incorrect?
-               - Are prop interfaces outdated?
+            3. **Check for Actual Problems / 檢查實際問題**: For each code change, determine if existing docs are now WRONG:
+               對於每個代碼變更，判斷現有文檔是否現在是錯誤的：
+               - Do code examples still work? / 代碼示例是否仍然有效？
+               - Are API signatures/types now incorrect? / API 簽名/類型是否現在不正確？
+               - Are prop interfaces outdated? / 屬性接口是否已過時？
 
-            4. **Fix Only What's Broken**: If you find documentation that is actually wrong:
-               - Fix incorrect code examples
-               - Update wrong API signatures and types
+            4. **Fix Only What's Broken / 只修復錯誤的部分**: If you find documentation that is actually wrong:
+               如果你發現文檔確實有誤：
+               - Fix incorrect code examples / 修復不正確的代碼示例
+               - Update wrong API signatures and types / 更新錯誤的 API 簽名和類型
                - Add docs ONLY for significant new features that have zero documentation
+                 僅為完全沒有文檔的重要新功能添加文檔
 
-            5. **Create a PR**: If you made any changes:
-               - Create a new branch from main
-               - Commit all documentation updates
-               - Create a PR with a summary of what was fixed
+            5. **Create a PR / 創建 PR**: If you made any changes:
+               如果你做了任何變更：
+               - Create a new branch from main / 從 main 創建新分支
+               - Commit all documentation updates / 提交所有文檔更新
+               - Create a PR with a summary of what was fixed / 創建 PR 並總結修復內容
 
-            ## CRITICAL Guidelines
+            ## CRITICAL Guidelines / 關鍵指南
             - Documentation is a LIVING DOCUMENT - only fix things that are actually WRONG
-            - DO NOT add changelog-style entries
-            - ONLY update docs when they are incorrect or misleading
+              文檔是活文檔 - 只修復實際錯誤的內容
+            - DO NOT add changelog-style entries / 不要添加變更日誌式條目
+            - ONLY update docs when they are incorrect or misleading / 僅在文檔不正確或誤導時更新
             - If no problems are found, report that and DO NOT create a PR
+              如果未發現問題，報告並不要創建 PR
           claude_args: |
             --max-turns 30
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*)"
 
-      - name: Report no changes
+      - name: Report no changes / 報告無變更
+        # 條件：沒有代碼變更時執行
+        # Condition: Run when there are no code changes
         if: steps.check-changes.outputs.has_changes == 'false'
         run: |
           echo "No code changes found in the last ${{ github.event.inputs.days_back || '30' }} days."

--- a/.github/workflows/scheduled-claude-code-quality.yml
+++ b/.github/workflows/scheduled-claude-code-quality.yml
@@ -1,38 +1,53 @@
-name: Scheduled - Code Quality Review
+name: Scheduled - Code Quality Review / 定期 - 代碼質量審查
+
+# 工作流程描述：每週隨機審查項目中的目錄以保持代碼質量
+# Workflow Description: Weekly random review of project directories to maintain code quality
 
 on:
   schedule:
-    # Run every Sunday at 8 AM UTC
+    # 運行時間：每週日上午 8 點（UTC）
+    # Run time: Every Sunday at 8 AM UTC
     - cron: '0 8 * * 0'
   workflow_dispatch:
+    # 手動觸發選項
+    # Manual trigger options
     inputs:
       num_dirs:
-        description: 'Number of random directories to review'
+        description: 'Number of random directories to review / 要審查的隨機目錄數量'
         required: false
         default: '3'
 
 concurrency:
+  # 並發控制：每次運行使用唯一 ID，不取消進行中的運行
+  # Concurrency control: Each run uses unique ID, doesn't cancel in-progress runs
   group: ${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  # 權限設定
+  # Permissions configuration
+  contents: write        # 寫入倉庫內容 / Write repository contents
+  pull-requests: write   # 創建 PR / Create PRs
 
 jobs:
   select-directories:
+    # 任務：選擇要審查的目錄
+    # Job: Select directories to review
     runs-on: ubuntu-latest
     outputs:
       directories: ${{ steps.select.outputs.directories }}
     steps:
-      - name: Checkout repository
+      - name: Checkout repository / 檢出倉庫
         uses: actions/checkout@v4
 
-      - name: Select random directories
+      - name: Select random directories / 選擇隨機目錄
+        # 步驟說明：在 src 目錄中隨機選擇包含 TypeScript 文件的目錄
+        # Step description: Randomly select directories in src that contain TypeScript files
         id: select
         run: |
           NUM_DIRS="${{ github.event.inputs.num_dirs || '3' }}"
 
+          # 在 src 中查找包含 TypeScript 文件的目錄
           # Find directories in src that have TypeScript files
           DIRS=$(find src -type d -exec sh -c 'ls "$1"/*.ts "$1"/*.tsx 2>/dev/null | grep -v -E "\.(test|spec|stories)\." | head -1' _ {} \; 2>/dev/null | \
             xargs -I {} dirname {} | \
@@ -45,6 +60,7 @@ jobs:
             exit 0
           fi
 
+          # 轉換為 JSON 數組
           # Convert to JSON array
           JSON_DIRS=$(echo "$DIRS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "directories=$JSON_DIRS" >> $GITHUB_OUTPUT
@@ -52,7 +68,11 @@ jobs:
           echo "$DIRS"
 
   review-directory:
+    # 任務：審查目錄
+    # Job: Review directory
     needs: select-directories
+    # 條件：僅在有目錄需要審查時執行
+    # Condition: Only run when there are directories to review
     if: needs.select-directories.outputs.directories != '[]'
     runs-on: ubuntu-latest
     strategy:
@@ -61,28 +81,32 @@ jobs:
       matrix:
         directory: ${{ fromJson(needs.select-directories.outputs.directories) }}
     steps:
-      - name: Checkout repository
+      - name: Checkout repository / 檢出倉庫
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
+      - name: Setup Node.js / 設置 Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install dependencies
+      - name: Install dependencies / 安裝依賴
         run: npm ci
 
-      - name: Generate branch name
+      - name: Generate branch name / 生成分支名稱
+        # 步驟說明：根據目錄名稱生成分支名稱
+        # Step description: Generate branch name based on directory name
         id: branch
         run: |
           DIR_SLUG=$(echo "${{ matrix.directory }}" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-30)
           BRANCH_NAME="claude/code-quality-${DIR_SLUG}-$(date +%Y%m%d)"
           echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - name: Claude Code Quality Review
+      - name: Claude Code Quality Review / Claude 代碼質量審查
+        # 步驟說明：使用 Claude 執行代碼質量審查並修復問題
+        # Step description: Execute code quality review and fix issues using Claude
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -92,66 +116,83 @@ jobs:
           branch_prefix: claude/code-quality-
           track_progress: true
           prompt: |
-            # Weekly Code Quality Review
+            # Weekly Code Quality Review / 每週代碼質量審查
 
             You are performing a scheduled code quality review of a specific directory.
+            你正在執行定期的代碼質量審查，針對特定目錄。
 
-            ## Target Directory
+            ## Target Directory / 目標目錄
             **Review: `${{ matrix.directory }}`**
+            **審查：`${{ matrix.directory }}`**
 
-            ## Your Tasks
+            ## Your Tasks / 你的任務
 
-            1. **Read the code review standards**: Read `.claude/agents/code-reviewer.md` for the full checklist
+            1. **Read the code review standards / 閱讀代碼審查標準**: Read `.claude/agents/code-reviewer.md` for the full checklist
+               閱讀 `.claude/agents/code-reviewer.md` 獲取完整的檢查清單
 
-            2. **Analyze all files in the directory**:
+            2. **Analyze all files in the directory / 分析目錄中的所有文件**:
                - List all .ts and .tsx files (excluding .test., .spec., .stories.)
-               - Read each file thoroughly
-               - Apply the review checklist
+                 列出所有 .ts 和 .tsx 文件（排除 .test.、.spec.、.stories.）
+               - Read each file thoroughly / 仔細閱讀每個文件
+               - Apply the review checklist / 應用審查檢查清單
 
-            3. **Focus on finding and FIXING issues**:
+            3. **Focus on finding and FIXING issues / 專注於發現和修復問題**:
                - TypeScript strict mode violations (any types, missing types)
+                 TypeScript 嚴格模式違規（any 類型、缺少類型）
                - React anti-patterns (bad useEffect, unnecessary memoization)
+                 React 反模式（錯誤的 useEffect、不必要的 memoization）
                - Code style issues (mutations, deep nesting, poor naming)
-               - Missing error handling
-               - Security issues
-               - Performance problems
+                 代碼風格問題（變異、深層嵌套、糟糕的命名）
+               - Missing error handling / 缺少錯誤處理
+               - Security issues / 安全問題
+               - Performance problems / 性能問題
 
-            4. **Make the fixes yourself**:
-               - Don't just report issues - FIX THEM
-               - Use Edit tool to update files
-               - Ensure fixes don't break anything
+            4. **Make the fixes yourself / 自己進行修復**:
+               - Don't just report issues - FIX THEM / 不要只是報告問題 - 修復它們
+               - Use Edit tool to update files / 使用 Edit 工具更新文件
+               - Ensure fixes don't break anything / 確保修復不會破壞任何東西
 
-            5. **Run verification**:
+            5. **Run verification / 運行驗證**:
                - `npm run lint` - verify no lint errors introduced
+                 `npm run lint` - 驗證沒有引入 lint 錯誤
                - If errors occur, fix them or revert changes
+                 如果出現錯誤，修復它們或還原變更
 
-            6. **Create PR if fixes were made**:
-               - Create a branch from main
-               - Commit all fixes with descriptive message
+            6. **Create PR if fixes were made / 如果有修復則創建 PR**:
+               - Create a branch from main / 從 main 創建分支
+               - Commit all fixes with descriptive message / 提交所有修復並附帶描述性訊息
                - PR title: "fix(${{ matrix.directory }}): code quality improvements"
-               - PR body should list fixes applied
+               - PR body should list fixes applied / PR 正文應列出應用的修復
 
-            ## Guidelines
-            - Be thorough but focused on this directory only
-            - Fix issues that are clear improvements
-            - Don't refactor working code just for style
+            ## Guidelines / 指南
+            - Be thorough but focused on this directory only / 要徹底但只專注於此目錄
+            - Fix issues that are clear improvements / 修復明確改進的問題
+            - Don't refactor working code just for style / 不要僅為風格而重構可運行的代碼
             - If no issues found, report that and skip PR creation
+              如果未發現問題，報告並跳過 PR 創建
           claude_args: |
             --max-turns 35
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm run lint*)"
 
   report-completion:
+    # 任務：報告完成狀態
+    # Job: Report completion status
     needs: [select-directories, review-directory]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Summary
+      - name: Summary / 摘要
+        # 步驟說明：生成工作流程摘要
+        # Step description: Generate workflow summary
         run: |
           echo "## Code Quality Review Complete" >> $GITHUB_STEP_SUMMARY
+          echo "## 代碼質量審查完成" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Reviewed directories:" >> $GITHUB_STEP_SUMMARY
+          echo "已審查的目錄：" >> $GITHUB_STEP_SUMMARY
           echo '${{ needs.select-directories.outputs.directories }}' | jq -r '.[]' | while read dir; do
             echo "- \`$dir\`" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Check for any PRs created by this workflow." >> $GITHUB_STEP_SUMMARY
+          echo "檢查此工作流程創建的任何 PR。" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,80 +1,133 @@
 # Project Name
+# 專案名稱
 
 > This is an example CLAUDE.md file showing how to configure Claude Code for your project.
+> 這是一個示範 CLAUDE.md 檔案，展示如何為您的專案設定 Claude Code。
 
 ## Quick Facts
+## 快速概覽
 
 - **Stack**: React, TypeScript, Node.js
+- **技術棧**：React, TypeScript, Node.js
 - **Test Command**: `npm test`
+- **測試命令**：`npm test`
 - **Lint Command**: `npm run lint`
+- **程式碼檢查命令**：`npm run lint`
 - **Build Command**: `npm run build`
+- **建置命令**：`npm run build`
 
 ## Key Directories
+## 主要目錄
 
 - `src/components/` - React components
+- `src/components/` - React 元件
 - `src/hooks/` - Custom React hooks
+- `src/hooks/` - 自訂 React hooks
 - `src/utils/` - Utility functions
+- `src/utils/` - 工具函數
 - `src/api/` - API client code
+- `src/api/` - API 客戶端程式碼
 - `tests/` - Test files
+- `tests/` - 測試檔案
 
 ## Code Style
+## 程式碼風格
 
 - TypeScript strict mode enabled
+- 啟用 TypeScript 嚴格模式
 - Prefer `interface` over `type` (except unions/intersections)
+- 優先使用 `interface` 而非 `type`（聯集/交集除外）
 - No `any` - use `unknown` instead
+- 不使用 `any` - 改用 `unknown`
 - Use early returns, avoid nested conditionals
+- 使用提前返回，避免巢狀條件判斷
 - Prefer composition over inheritance
+- 優先使用組合而非繼承
 
 ## Git Conventions
+## Git 慣例
 
 - **Branch naming**: `{initials}/{description}` (e.g., `jd/fix-login`)
+- **分支命名**：`{縮寫}/{描述}` (例如：`jd/fix-login`)
 - **Commit format**: Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
+- **提交格式**：Conventional Commits（`feat:`、`fix:`、`docs:` 等）
 - **PR titles**: Same as commit format
+- **PR 標題**：與提交格式相同
 
 ## Critical Rules
+## 重要規則
 
 ### Error Handling
+### 錯誤處理
+
 - NEVER swallow errors silently
+- 絕不靜默吞沒錯誤
 - Always show user feedback for errors
+- 總是向使用者顯示錯誤訊息
 - Log errors for debugging
+- 記錄錯誤以便除錯
 
 ### UI States
+### UI 狀態
+
 - Always handle: loading, error, empty, success states
+- 總是處理：載入中、錯誤、空狀態、成功狀態
 - Show loading ONLY when no data exists
+- 只在沒有資料時顯示載入中
 - Every list needs an empty state
+- 每個列表都需要空狀態
 
 ### Mutations
+### 資料變更
+
 - Disable buttons during async operations
+- 在非同步操作期間停用按鈕
 - Show loading indicator on buttons
+- 在按鈕上顯示載入指示器
 - Always have onError handler with user feedback
+- 總是提供帶有使用者回饋的 onError 處理器
 
 ## Testing
+## 測試
 
 - Write failing test first (TDD)
+- 先寫失敗的測試（TDD）
 - Use factory pattern: `getMockX(overrides)`
+- 使用工廠模式：`getMockX(overrides)`
 - Test behavior, not implementation
+- 測試行為，而非實作
 - Run tests before committing
+- 提交前執行測試
 
 ## Skill Activation
+## 技能啟用
 
 Before implementing ANY task, check if relevant skills apply:
+在實作任何任務之前，請檢查是否適用相關技能：
 
 - Creating tests → `testing-patterns` skill
+- 建立測試 → `testing-patterns` 技能
 - Building forms → `formik-patterns` skill
+- 建立表單 → `formik-patterns` 技能
 - GraphQL operations → `graphql-schema` skill
+- GraphQL 操作 → `graphql-schema` 技能
 - Debugging issues → `systematic-debugging` skill
+- 除錯問題 → `systematic-debugging` 技能
 - UI components → `react-ui-patterns` skill
+- UI 元件 → `react-ui-patterns` 技能
 
 ## Common Commands
+## 常用命令
 
 ```bash
 # Development
-npm run dev          # Start dev server
-npm test             # Run tests
-npm run lint         # Run linter
-npm run typecheck    # Check types
+# 開發
+npm run dev          # Start dev server (啟動開發伺服器)
+npm test             # Run tests (執行測試)
+npm run lint         # Run linter (執行程式碼檢查)
+npm run typecheck    # Check types (檢查型別)
 
 # Git
-npm run commit       # Interactive commit
-gh pr create         # Create PR
+npm run commit       # Interactive commit (互動式提交)
+gh pr create         # Create PR (建立 PR)
 ```

--- a/README.md
+++ b/README.md
@@ -1,54 +1,83 @@
 # Claude Code Project Configuration Showcase
+# Claude Code 專案配置範例展示
 
 > Most software engineers are seriously sleeping on how good LLM agents are right now, especially something like Claude Code.
 
+> 大多數軟體工程師嚴重低估了當前 LLM 代理的強大能力，尤其是像 Claude Code 這樣的工具。
+
 Once you've got Claude Code set up, you can point it at your codebase, have it learn your conventions, pull in best practices, and refine everything until it's basically operating like a super-powered teammate. **The real unlock is building a solid set of reusable "[skills](#skills---domain-knowledge)" plus a few "[agents](#agents---specialized-assistants)" for the stuff you do all the time.**
 
+當您設定好 Claude Code 後，您可以將它指向您的程式碼庫，讓它學習您的慣例，引入最佳實踐，並不斷優化，直到它基本上像一個超級強大的隊友一樣運作。**真正的關鍵是建立一套堅實的可重用「[技能](#skills---domain-knowledge)」，再加上一些「[代理](#agents---specialized-assistants)」來處理您經常做的事情。**
+
 ### What This Looks Like in Practice
+### 實際應用範例
 
 **Custom UI Library?** We have a [skill that explains exactly how to use it](.claude/skills/core-components/SKILL.md). Same for [how we write tests](.claude/skills/testing-patterns/SKILL.md), [how we structure GraphQL](.claude/skills/graphql-schema/SKILL.md), and basically how we want everything done in our repo. So when Claude generates code, it already matches our patterns and standards out of the box.
 
+**自訂 UI 函式庫？** 我們有一個[技能詳細說明如何使用它](.claude/skills/core-components/SKILL.md)。[如何撰寫測試](.claude/skills/testing-patterns/SKILL.md)、[如何組織 GraphQL](.claude/skills/graphql-schema/SKILL.md)，以及基本上我們希望在程式碼庫中如何完成所有事情，都有相應的技能。因此，當 Claude 生成程式碼時，它已經符合我們的模式和標準。
+
 **Automated Quality Gates?** We use [hooks](.claude/settings.json) to auto-format code, run tests when test files change, type-check TypeScript, and even [block edits on the main branch](.claude/settings.md). Claude Code also created a bunch of ESLint automation, including custom rules and lint checks that catch issues before they hit review.
 
+**自動化品質閘門？** 我們使用[鉤子](.claude/settings.json)來自動格式化程式碼，在測試檔案變更時執行測試，檢查 TypeScript 類型，甚至[阻止在主分支上進行編輯](.claude/settings.md)。Claude Code 還創建了大量 ESLint 自動化，包括自訂規則和 lint 檢查，在程式碼審查之前就能捕獲問題。
+
 **Deep Code Review?** We have a [code review agent](.claude/agents/code-reviewer.md) that Claude runs after changes are made. It follows a detailed checklist covering TypeScript strict mode, error handling, loading states, mutation patterns, and more. When a PR goes up, we have a [GitHub Action](.github/workflows/pr-claude-code-review.yml) that does a full PR review automatically.
+
+**深度程式碼審查？** 我們有一個[程式碼審查代理](.claude/agents/code-reviewer.md)，Claude 在進行變更後會執行它。它遵循詳細的檢查清單，涵蓋 TypeScript 嚴格模式、錯誤處理、載入狀態、mutation 模式等等。當 PR 提交時，我們有一個 [GitHub Action](.github/workflows/pr-claude-code-review.yml) 會自動進行完整的 PR 審查。
 
 **Scheduled Maintenance?** We've got GitHub workflow agents that run on a schedule:
 - [Monthly docs sync](.github/workflows/scheduled-claude-code-docs-sync.yml) - Reads commits from the last month and makes sure docs are still aligned
 - [Weekly code quality](.github/workflows/scheduled-claude-code-quality.yml) - Reviews random directories and auto-fixes issues
 - [Biweekly dependency audit](.github/workflows/scheduled-claude-code-dependency-audit.yml) - Safe dependency updates with test verification
 
+**定期維護？** 我們有按計劃執行的 GitHub 工作流程代理：
+- [每月文件同步](.github/workflows/scheduled-claude-code-docs-sync.yml) - 讀取上個月的提交並確保文件仍然一致
+- [每週程式碼品質檢查](.github/workflows/scheduled-claude-code-quality.yml) - 審查隨機目錄並自動修復問題
+- [雙週依賴審計](.github/workflows/scheduled-claude-code-dependency-audit.yml) - 透過測試驗證進行安全的依賴更新
+
 **Intelligent Skill Suggestions?** We built a [skill evaluation system](#skill-evaluation-hooks) that analyzes every prompt and automatically suggests which skills Claude should activate based on keywords, file paths, and intent patterns.
+
+**智慧技能建議？** 我們建立了一個[技能評估系統](#skill-evaluation-hooks)，它會分析每個提示，並根據關鍵字、檔案路徑和意圖模式自動建議 Claude 應該啟用哪些技能。
 
 A ton of maintenance and quality work is just... automated. It runs ridiculously smoothly.
 
+大量的維護和品質工作就這樣...自動化了。運行得非常順暢。
+
 **JIRA/Linear Integration?** We connect Claude Code to our ticket system via [MCP servers](.mcp.json). Now Claude can read the ticket, understand the requirements, implement the feature, update the ticket status, and even create new tickets if it finds bugs along the way. The [`/ticket` command](.claude/commands/ticket.md) handles the entire workflow—from reading acceptance criteria to linking the PR back to the ticket.
+
+**JIRA/Linear 整合？** 我們透過 [MCP 伺服器](.mcp.json)將 Claude Code 連接到我們的工單系統。現在 Claude 可以讀取工單、理解需求、實作功能、更新工單狀態，甚至在過程中發現錯誤時建立新工單。[`/ticket` 指令](.claude/commands/ticket.md)處理整個工作流程——從讀取驗收標準到將 PR 連結回工單。
 
 We even use Claude Code for ticket triage. It reads the ticket, digs into the codebase, and leaves a comment with what it thinks should be done. So when an engineer picks it up, they're basically starting halfway through already.
 
+我們甚至使用 Claude Code 進行工單分類。它讀取工單，深入程式碼庫，並留下註解說明它認為應該做什麼。所以當工程師接手時，他們基本上已經完成一半了。
+
 **There is so much low-hanging fruit here that it honestly blows my mind people aren't all over it.**
+
+**這裡有太多唾手可得的成果，說實話，人們沒有全力投入讓我感到震驚。**
 
 ---
 
 ## Table of Contents
+## 目錄
 
-- [Directory Structure](#directory-structure)
-- [Quick Start](#quick-start)
-- [Configuration Reference](#configuration-reference)
-  - [CLAUDE.md - Project Memory](#claudemd---project-memory)
-  - [settings.json - Hooks & Environment](#settingsjson---hooks--environment)
-  - [MCP Servers - External Integrations](#mcp-servers---external-integrations)
-  - [LSP Servers - Real-Time Code Intelligence](#lsp-servers---real-time-code-intelligence)
-  - [Skill Evaluation Hooks](#skill-evaluation-hooks)
-  - [Skills - Domain Knowledge](#skills---domain-knowledge)
-  - [Agents - Specialized Assistants](#agents---specialized-assistants)
-  - [Commands - Slash Commands](#commands---slash-commands)
-- [GitHub Actions Workflows](#github-actions-workflows)
-- [Best Practices](#best-practices)
-- [Examples in This Repository](#examples-in-this-repository)
+- [Directory Structure](#directory-structure) / [目錄結構](#directory-structure)
+- [Quick Start](#quick-start) / [快速開始](#quick-start)
+- [Configuration Reference](#configuration-reference) / [配置參考](#configuration-reference)
+  - [CLAUDE.md - Project Memory](#claudemd---project-memory) / [CLAUDE.md - 專案記憶](#claudemd---project-memory)
+  - [settings.json - Hooks & Environment](#settingsjson---hooks--environment) / [settings.json - 鉤子與環境](#settingsjson---hooks--environment)
+  - [MCP Servers - External Integrations](#mcp-servers---external-integrations) / [MCP 伺服器 - 外部整合](#mcp-servers---external-integrations)
+  - [LSP Servers - Real-Time Code Intelligence](#lsp-servers---real-time-code-intelligence) / [LSP 伺服器 - 即時程式碼智能](#lsp-servers---real-time-code-intelligence)
+  - [Skill Evaluation Hooks](#skill-evaluation-hooks) / [技能評估鉤子](#skill-evaluation-hooks)
+  - [Skills - Domain Knowledge](#skills---domain-knowledge) / [技能 - 領域知識](#skills---domain-knowledge)
+  - [Agents - Specialized Assistants](#agents---specialized-assistants) / [代理 - 專業助手](#agents---specialized-assistants)
+  - [Commands - Slash Commands](#commands---slash-commands) / [指令 - 斜線指令](#commands---slash-commands)
+- [GitHub Actions Workflows](#github-actions-workflows) / [GitHub Actions 工作流程](#github-actions-workflows)
+- [Best Practices](#best-practices) / [最佳實踐](#best-practices)
+- [Examples in This Repository](#examples-in-this-repository) / [本程式碼庫中的範例](#examples-in-this-repository)
 
 ---
 
 ## Directory Structure
+## 目錄結構
 
 ```
 your-project/
@@ -96,16 +125,21 @@ your-project/
 ---
 
 ## Quick Start
+## 快速開始
 
 ### 1. Create the `.claude` directory
+### 1. 建立 `.claude` 目錄
 
 ```bash
 mkdir -p .claude/{agents,commands,hooks,skills}
 ```
 
 ### 2. Add a CLAUDE.md file
+### 2. 新增 CLAUDE.md 檔案
 
 Create `CLAUDE.md` in your project root with your project's key information. See [CLAUDE.md](CLAUDE.md) for a complete example.
+
+在專案根目錄建立 `CLAUDE.md`，包含專案的關鍵資訊。完整範例請參閱 [CLAUDE.md](CLAUDE.md)。
 
 ```markdown
 # Project Name
@@ -127,8 +161,11 @@ Create `CLAUDE.md` in your project root with your project's key information. See
 ```
 
 ### 3. Add settings.json with hooks
+### 3. 新增帶有鉤子的 settings.json
 
 Create `.claude/settings.json`. See [settings.json](.claude/settings.json) for a full example with auto-formatting, testing, and more.
+
+建立 `.claude/settings.json`。完整範例包含自動格式化、測試等功能，請參閱 [settings.json](.claude/settings.json)。
 
 ```json
 {
@@ -150,8 +187,11 @@ Create `.claude/settings.json`. See [settings.json](.claude/settings.json) for a
 ```
 
 ### 4. Add your first skill
+### 4. 新增您的第一個技能
 
 Create `.claude/skills/testing-patterns/SKILL.md`. See [testing-patterns/SKILL.md](.claude/skills/testing-patterns/SKILL.md) for a comprehensive example.
+
+建立 `.claude/skills/testing-patterns/SKILL.md`。完整範例請參閱 [testing-patterns/SKILL.md](.claude/skills/testing-patterns/SKILL.md)。
 
 ```markdown
 ---
@@ -173,18 +213,29 @@ description: Jest testing patterns for this project. Use when writing tests, cre
 
 > **Tip:** The `description` field is critical—Claude uses it to decide when to apply the skill. Include keywords users would naturally mention.
 
+> **提示：** `description` 欄位至關重要——Claude 使用它來決定何時應用該技能。包含使用者自然會提及的關鍵字。
+
 ---
 
 ## Configuration Reference
+## 配置參考
 
 ### CLAUDE.md - Project Memory
+### CLAUDE.md - 專案記憶
 
 CLAUDE.md is Claude's persistent memory that loads automatically at session start.
+
+CLAUDE.md 是 Claude 的持久記憶，會在會話開始時自動載入。
 
 **Locations (in order of precedence):**
 1. `.claude/CLAUDE.md` (project, in .claude folder)
 2. `./CLAUDE.md` (project root)
 3. `~/.claude/CLAUDE.md` (user-level, all projects)
+
+**位置（依優先順序）：**
+1. `.claude/CLAUDE.md`（專案，在 .claude 資料夾中）
+2. `./CLAUDE.md`（專案根目錄）
+3. `~/.claude/CLAUDE.md`（使用者層級，所有專案）
 
 **What to include:**
 - Project stack and architecture overview
@@ -193,19 +244,36 @@ CLAUDE.md is Claude's persistent memory that loads automatically at session star
 - Important directories and their purposes
 - Critical rules and constraints
 
+**應包含的內容：**
+- 專案技術堆疊和架構概述
+- 關鍵指令（測試、建置、lint、部署）
+- 程式碼風格指南
+- 重要目錄及其用途
+- 關鍵規則和約束
+
 **📄 Example:** [CLAUDE.md](CLAUDE.md)
+
+**📄 範例：** [CLAUDE.md](CLAUDE.md)
 
 ---
 
 ### settings.json - Hooks & Environment
+### settings.json - 鉤子與環境
 
 The main configuration file for hooks, environment variables, and permissions.
 
+hooks、環境變數和權限的主要配置檔案。
+
 **Location:** `.claude/settings.json`
+
+**位置：** `.claude/settings.json`
 
 **📄 Example:** [settings.json](.claude/settings.json) | [Human-readable docs](.claude/settings.md)
 
+**📄 範例：** [settings.json](.claude/settings.json) | [易讀文件](.claude/settings.md)
+
 #### Hook Events
+#### 鉤子事件
 
 | Event | When It Fires | Use Case |
 |-------|---------------|----------|
@@ -214,7 +282,15 @@ The main configuration file for hooks, environment variables, and permissions.
 | `UserPromptSubmit` | User submits prompt | Add context, suggest skills |
 | `Stop` | Agent finishes | Decide if Claude should continue |
 
+| 事件 | 觸發時機 | 使用案例 |
+|-------|---------------|----------|
+| `PreToolUse` | 工具執行前 | 阻止在主分支上編輯、驗證指令 |
+| `PostToolUse` | 工具完成後 | 自動格式化、執行測試、lint |
+| `UserPromptSubmit` | 使用者提交提示時 | 新增上下文、建議技能 |
+| `Stop` | 代理完成時 | 決定 Claude 是否應該繼續 |
+
 #### Hook Response Format
+#### 鉤子回應格式
 
 ```json
 {
@@ -227,21 +303,35 @@ The main configuration file for hooks, environment variables, and permissions.
 ```
 
 #### Exit Codes
+#### 退出代碼
+
 - `0` - Success
 - `2` - Blocking error (PreToolUse only, blocks the tool)
 - Other - Non-blocking error
 
+- `0` - 成功
+- `2` - 阻塞錯誤（僅 PreToolUse，阻止工具執行）
+- 其他 - 非阻塞錯誤
+
 ---
 
 ### MCP Servers - External Integrations
+### MCP 伺服器 - 外部整合
 
 MCP (Model Context Protocol) servers let Claude Code connect to external tools like JIRA, GitHub, Slack, databases, and more. This is how you enable workflows like "read a ticket, implement it, and update the ticket status."
 
+MCP（模型上下文協議）伺服器讓 Claude Code 能夠連接到外部工具，如 JIRA、GitHub、Slack、資料庫等。這就是您如何啟用「讀取工單、實作它並更新工單狀態」等工作流程。
+
 **Location:** `.mcp.json` (project root, committed to git for team sharing)
+
+**位置：** `.mcp.json`（專案根目錄，提交到 git 供團隊共享）
 
 **📄 Example:** [.mcp.json](.mcp.json)
 
+**📄 範例：** [.mcp.json](.mcp.json)
+
 #### How MCP Works
+#### MCP 如何運作
 
 ```
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
@@ -252,7 +342,10 @@ MCP (Model Context Protocol) servers let Claude Code connect to external tools l
 
 MCP servers run locally and provide Claude with tools to interact with external services. When you configure a JIRA MCP server, Claude gets tools like `jira_get_issue`, `jira_update_issue`, `jira_create_issue`, etc.
 
+MCP 伺服器在本地運行，並為 Claude 提供與外部服務互動的工具。當您配置 JIRA MCP 伺服器時，Claude 會獲得 `jira_get_issue`、`jira_update_issue`、`jira_create_issue` 等工具。
+
 #### .mcp.json Format
+#### .mcp.json 格式
 
 ```json
 {
@@ -271,6 +364,8 @@ MCP servers run locally and provide Claude with tools to interact with external 
 
 **Fields:**
 
+**欄位：**
+
 | Field | Required | Description |
 |-------|----------|-------------|
 | `type` | Yes | Server type: `stdio` (local process) or `http` (remote) |
@@ -280,7 +375,17 @@ MCP servers run locally and provide Claude with tools to interact with external 
 | `url` | For http | Remote server URL |
 | `headers` | For http | HTTP headers for authentication |
 
+| 欄位 | 必需 | 描述 |
+|-------|----------|-------------|
+| `type` | 是 | 伺服器類型：`stdio`（本地進程）或 `http`（遠端） |
+| `command` | stdio 需要 | 要執行的可執行檔（例如 `npx`、`python`） |
+| `args` | 否 | 命令列參數 |
+| `env` | 否 | 環境變數（支援 `${VAR}` 擴展） |
+| `url` | http 需要 | 遠端伺服器 URL |
+| `headers` | http 需要 | 用於身份驗證的 HTTP 標頭 |
+
 #### Example: JIRA Integration
+#### 範例：JIRA 整合
 
 ```json
 {
@@ -306,7 +411,16 @@ MCP servers run locally and provide Claude with tools to interact with external 
 - Create new tickets for bugs found during development
 - Link PRs to tickets
 
+**這能實現什麼：**
+- 讀取工單詳情、驗收標準和註解
+- 更新工單狀態（待辦 → 進行中 → 審查中）
+- 新增進度更新註解
+- 為開發過程中發現的錯誤建立新工單
+- 將 PR 連結到工單
+
 **Example workflow with [`/ticket` command](.claude/commands/ticket.md):**
+
+**使用 [`/ticket` 指令](.claude/commands/ticket.md)的範例工作流程：**
 ```
 You: /ticket PROJ-123
 
@@ -333,8 +447,11 @@ Claude:
 ```
 
 #### Common MCP Server Configurations
+#### 常見 MCP 伺服器配置
 
 **Issue Tracking:**
+
+**問題追蹤：**
 ```json
 {
   "jira": {
@@ -357,6 +474,8 @@ Claude:
 ```
 
 **Code & DevOps:**
+
+**程式碼與 DevOps：**
 ```json
 {
   "github": {
@@ -378,6 +497,8 @@ Claude:
 ```
 
 **Communication:**
+
+**通訊：**
 ```json
 {
   "slack": {
@@ -393,6 +514,8 @@ Claude:
 ```
 
 **Databases:**
+
+**資料庫：**
 ```json
 {
   "postgres": {
@@ -405,12 +528,19 @@ Claude:
 ```
 
 #### Environment Variables
+#### 環境變數
 
 MCP configs support variable expansion:
 - `${VAR}` - Expands to environment variable (fails if not set)
 - `${VAR:-default}` - Uses default if VAR is not set
 
+MCP 配置支援變數擴展：
+- `${VAR}` - 擴展為環境變數（如果未設定則失敗）
+- `${VAR:-default}` - 如果 VAR 未設定則使用預設值
+
 Set these in your shell profile or `.env` file (don't commit secrets!):
+
+在您的 shell 設定檔或 `.env` 檔案中設定這些變數（不要提交機密資訊！）：
 ```bash
 export JIRA_HOST="https://yourcompany.atlassian.net"
 export JIRA_EMAIL="you@company.com"
@@ -418,8 +548,11 @@ export JIRA_API_TOKEN="your-api-token"
 ```
 
 #### Settings for MCP
+#### MCP 設定
 
 In `settings.json`, you can auto-approve MCP servers:
+
+在 `settings.json` 中，您可以自動批准 MCP 伺服器：
 
 ```json
 {
@@ -428,6 +561,8 @@ In `settings.json`, you can auto-approve MCP servers:
 ```
 
 Or approve specific servers:
+
+或批准特定伺服器：
 ```json
 {
   "enabledMcpjsonServers": ["jira", "github", "slack"]
@@ -437,14 +572,22 @@ Or approve specific servers:
 ---
 
 ### LSP Servers - Real-Time Code Intelligence
+### LSP 伺服器 - 即時程式碼智能
 
 LSP (Language Server Protocol) gives Claude real-time understanding of your code—type information, errors, completions, and navigation. Instead of just reading text, Claude can "see" your code the way your IDE does.
 
+LSP（語言伺服器協議）讓 Claude 能即時理解您的程式碼——類型資訊、錯誤、自動完成和導航。Claude 不僅僅是讀取文字，而是能像您的 IDE 一樣「看到」您的程式碼。
+
 **Why this matters:** When you edit TypeScript, Claude immediately knows if you introduced a type error. When you reference a function, Claude can jump to its definition. This dramatically improves code generation quality.
 
+**為什麼這很重要：** 當您編輯 TypeScript 時，Claude 會立即知道您是否引入了類型錯誤。當您引用一個函式時，Claude 可以跳轉到它的定義。這大幅提升了程式碼生成的品質。
+
 #### Enabling LSP
+#### 啟用 LSP
 
 LSP support is enabled through plugins in `settings.json`:
+
+LSP 支援透過 `settings.json` 中的外掛程式啟用：
 
 ```json
 {
@@ -456,6 +599,7 @@ LSP support is enabled through plugins in `settings.json`:
 ```
 
 #### What Claude Gets from LSP
+#### Claude 從 LSP 獲得什麼
 
 | Feature | Description |
 |---------|-------------|
@@ -464,7 +608,15 @@ LSP support is enabled through plugins in `settings.json`:
 | **Code Navigation** | Go to definition, find references |
 | **Completions** | Context-aware symbol suggestions |
 
+| 功能 | 描述 |
+|---------|-------------|
+| **診斷** | 每次編輯後的即時錯誤和警告 |
+| **類型資訊** | 懸停資訊、函式簽名、類型定義 |
+| **程式碼導航** | 跳轉到定義、查找引用 |
+| **自動完成** | 上下文感知的符號建議 |
+
 #### Available LSP Plugins
+#### 可用的 LSP 外掛程式
 
 | Plugin | Language | Install Binary First |
 |--------|----------|---------------------|
@@ -472,9 +624,18 @@ LSP support is enabled through plugins in `settings.json`:
 | `pyright-lsp` | Python | `pip install pyright` |
 | `rust-lsp` | Rust | `rustup component add rust-analyzer` |
 
+| 外掛程式 | 語言 | 先安裝執行檔 |
+|--------|----------|---------------------|
+| `typescript-lsp` | TypeScript/JavaScript | `npm install -g typescript-language-server typescript` |
+| `pyright-lsp` | Python | `pip install pyright` |
+| `rust-lsp` | Rust | `rustup component add rust-analyzer` |
+
 #### Custom LSP Configuration
+#### 自訂 LSP 配置
 
 For advanced setups, create `.lsp.json`:
+
+對於進階設定，建立 `.lsp.json`：
 
 ```json
 {
@@ -495,20 +656,29 @@ For advanced setups, create `.lsp.json`:
 ```
 
 #### Troubleshooting
+#### 疑難排解
 
 If LSP isn't working:
 
+如果 LSP 無法運作：
+
 1. **Check binary is installed:**
+
+   **檢查執行檔是否已安裝：**
    ```bash
    which typescript-language-server  # Should return a path
    ```
 
 2. **Enable debug logging:**
+
+   **啟用除錯日誌：**
    ```bash
    claude --enable-lsp-logging
    ```
 
 3. **Check plugin status:**
+
+   **檢查外掛程式狀態：**
    ```bash
    claude /plugin  # View Errors tab
    ```
@@ -516,14 +686,22 @@ If LSP isn't working:
 ---
 
 ### Skill Evaluation Hooks
+### 技能評估鉤子
 
 One of our most powerful automations is the **skill evaluation system**. It runs on every prompt submission and intelligently suggests which skills Claude should activate.
 
+我們最強大的自動化之一是**技能評估系統**。它在每次提示提交時運行，並智慧地建議 Claude 應該啟用哪些技能。
+
 **📄 Files:** [skill-eval.sh](.claude/hooks/skill-eval.sh) | [skill-eval.js](.claude/hooks/skill-eval.js) | [skill-rules.json](.claude/hooks/skill-rules.json)
 
+**📄 檔案：** [skill-eval.sh](.claude/hooks/skill-eval.sh) | [skill-eval.js](.claude/hooks/skill-eval.js) | [skill-rules.json](.claude/hooks/skill-rules.json)
+
 #### How It Works
+#### 運作方式
 
 When you submit a prompt, the `UserPromptSubmit` hook triggers our skill evaluation engine:
+
+當您提交提示時，`UserPromptSubmit` 鉤子會觸發我們的技能評估引擎：
 
 1. **Prompt Analysis** - The engine analyzes your prompt for:
    - **Keywords**: Simple word matching (`test`, `form`, `graphql`, `bug`)
@@ -531,7 +709,23 @@ When you submit a prompt, the `UserPromptSubmit` hook triggers our skill evaluat
    - **File Paths**: Extracts mentioned files (`src/components/Button.tsx`)
    - **Intent**: Detects what you're trying to do (`create.*test`, `fix.*bug`)
 
+1. **提示分析** - 引擎分析您的提示以尋找：
+   - **關鍵字**：簡單的字詞匹配（`test`、`form`、`graphql`、`bug`）
+   - **模式**：正則表達式匹配（`\btest(?:s|ing)?\b`、`\.stories\.`）
+   - **檔案路徑**：提取提及的檔案（`src/components/Button.tsx`）
+   - **意圖**：檢測您試圖做什麼（`create.*test`、`fix.*bug`）
+
 2. **Directory Mapping** - File paths are mapped to relevant skills:
+   ```json
+   {
+     "src/components/core": "core-components",
+     "src/graphql": "graphql-schema",
+     ".github/workflows": "github-actions",
+     "src/hooks": "react-ui-patterns"
+   }
+   ```
+
+2. **目錄映射** - 檔案路徑被映射到相關技能：
    ```json
    {
      "src/components/core": "core-components",
@@ -552,7 +746,20 @@ When you submit a prompt, the `UserPromptSubmit` hook triggers our skill evaluat
    }
    ```
 
+3. **信心評分** - 每種觸發類型都有一個分數值：
+   ```json
+   {
+     "keyword": 2,
+     "keywordPattern": 3,
+     "pathPattern": 4,
+     "directoryMatch": 5,
+     "intentPattern": 4
+   }
+   ```
+
 4. **Skill Suggestion** - Skills exceeding the confidence threshold are suggested with reasons:
+
+4. **技能建議** - 超過信心閾值的技能會附帶原因被建議：
    ```
    SKILL ACTIVATION REQUIRED
 
@@ -566,8 +773,11 @@ When you submit a prompt, the `UserPromptSubmit` hook triggers our skill evaluat
    ```
 
 #### Configuration
+#### 配置
 
 Skills are defined in [skill-rules.json](.claude/hooks/skill-rules.json):
+
+技能定義在 [skill-rules.json](.claude/hooks/skill-rules.json) 中：
 
 ```json
 {
@@ -589,13 +799,18 @@ Skills are defined in [skill-rules.json](.claude/hooks/skill-rules.json):
 ```
 
 #### Adding to Your Project
+#### 新增到您的專案
 
 1. Copy the hooks to your project:
+
+   **將鉤子複製到您的專案：**
    ```bash
    cp -r .claude/hooks/ your-project/.claude/hooks/
    ```
 
 2. Add the hook to your `settings.json`:
+
+   **將鉤子新增到您的 `settings.json`：**
    ```json
    {
      "hooks": {
@@ -616,13 +831,20 @@ Skills are defined in [skill-rules.json](.claude/hooks/skill-rules.json):
 
 3. Customize [skill-rules.json](.claude/hooks/skill-rules.json) with your project's skills and triggers.
 
+   **使用您專案的技能和觸發器自訂 [skill-rules.json](.claude/hooks/skill-rules.json)。**
+
 ---
 
 ### Skills - Domain Knowledge
+### 技能 - 領域知識
 
 Skills are markdown documents that teach Claude project-specific patterns and conventions.
 
+技能是 markdown 文件，教導 Claude 專案特定的模式和慣例。
+
 **Location:** `.claude/skills/{skill-name}/SKILL.md`
+
+**位置：** `.claude/skills/{skill-name}/SKILL.md`
 
 **📄 Examples:**
 - [testing-patterns](.claude/skills/testing-patterns/SKILL.md) - TDD, factory functions, mocking
@@ -632,7 +854,16 @@ Skills are markdown documents that teach Claude project-specific patterns and co
 - [core-components](.claude/skills/core-components/SKILL.md) - Design system, tokens
 - [formik-patterns](.claude/skills/formik-patterns/SKILL.md) - Form handling, validation
 
+**📄 範例：**
+- [testing-patterns](.claude/skills/testing-patterns/SKILL.md) - TDD、工廠函式、模擬
+- [systematic-debugging](.claude/skills/systematic-debugging/SKILL.md) - 四階段除錯方法
+- [react-ui-patterns](.claude/skills/react-ui-patterns/SKILL.md) - 載入狀態、錯誤處理
+- [graphql-schema](.claude/skills/graphql-schema/SKILL.md) - 查詢、mutation、程式碼生成
+- [core-components](.claude/skills/core-components/SKILL.md) - 設計系統、設計令牌
+- [formik-patterns](.claude/skills/formik-patterns/SKILL.md) - 表單處理、驗證
+
 #### SKILL.md Frontmatter Fields
+#### SKILL.md 前置資料欄位
 
 | Field | Required | Max Length | Description |
 |-------|----------|------------|-------------|
@@ -640,6 +871,13 @@ Skills are markdown documents that teach Claude project-specific patterns and co
 | `description` | **Yes** | 1024 chars | What the skill does and when to use it. Claude uses this to decide when to apply the skill. |
 | `allowed-tools` | No | - | Comma-separated list of tools Claude can use (e.g., `Read, Grep, Bash(npm:*)`). |
 | `model` | No | - | Specific model to use (e.g., `claude-sonnet-4-20250514`). |
+
+| 欄位 | 必需 | 最大長度 | 描述 |
+|-------|----------|------------|-------------|
+| `name` | **是** | 64 字元 | 僅限小寫字母、數字和連字符。應與目錄名稱匹配。 |
+| `description` | **是** | 1024 字元 | 技能的功能和使用時機。Claude 使用此欄位決定何時應用該技能。 |
+| `allowed-tools` | 否 | - | Claude 可以使用的工具清單，以逗號分隔（例如 `Read, Grep, Bash(npm:*)`）。 |
+| `model` | 否 | - | 要使用的特定模型（例如 `claude-sonnet-4-20250514`）。 |
 
 #### SKILL.md Format
 
@@ -676,6 +914,7 @@ model: claude-sonnet-4-20250514
 ```
 
 #### Best Practices for Skills
+#### 技能最佳實踐
 
 1. **Keep SKILL.md focused** - Under 500 lines; put detailed docs in separate referenced files
 2. **Write trigger-rich descriptions** - Claude uses semantic matching on descriptions to decide when to apply skills
@@ -683,19 +922,35 @@ model: claude-sonnet-4-20250514
 4. **Reference other skills** - Show how skills work together
 5. **Use exact filename** - Must be `SKILL.md` (case-sensitive)
 
+1. **保持 SKILL.md 專注** - 少於 500 行；將詳細文件放在單獨引用的檔案中
+2. **撰寫豐富的觸發描述** - Claude 使用語意匹配描述來決定何時應用技能
+3. **包含範例** - 展示好的和壞的模式與程式碼
+4. **引用其他技能** - 展示技能如何協同工作
+5. **使用精確的檔案名稱** - 必須是 `SKILL.md`（區分大小寫）
+
 ---
 
 ### Agents - Specialized Assistants
+### 代理 - 專業助手
 
 Agents are AI assistants with focused purposes and their own prompts.
 
+代理是具有特定目的和自己提示的 AI 助手。
+
 **Location:** `.claude/agents/{agent-name}.md`
+
+**位置：** `.claude/agents/{agent-name}.md`
 
 **📄 Examples:**
 - [code-reviewer.md](.claude/agents/code-reviewer.md) - Comprehensive code review with checklist
 - [github-workflow.md](.claude/agents/github-workflow.md) - Git commits, branches, PRs
 
+**📄 範例：**
+- [code-reviewer.md](.claude/agents/code-reviewer.md) - 包含檢查清單的全面程式碼審查
+- [github-workflow.md](.claude/agents/github-workflow.md) - Git 提交、分支、PR
+
 #### Agent Format
+#### 代理格式
 
 ```markdown
 ---
@@ -720,6 +975,7 @@ You are a senior code reviewer...
 ```
 
 #### Agent Configuration Fields
+#### 代理配置欄位
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -728,13 +984,25 @@ You are a senior code reviewer...
 | `model` | No | `sonnet`, `opus`, or `haiku` |
 | `tools` | No | Comma-separated tool list |
 
+| 欄位 | 必需 | 描述 |
+|-------|----------|-------------|
+| `name` | 是 | 小寫加連字符 |
+| `description` | 是 | 何時/為何使用（最多 1024 字元） |
+| `model` | 否 | `sonnet`、`opus` 或 `haiku` |
+| `tools` | 否 | 以逗號分隔的工具清單 |
+
 ---
 
 ### Commands - Slash Commands
+### 指令 - 斜線指令
 
 Custom commands invoked with `/command-name`.
 
+使用 `/command-name` 呼叫的自訂指令。
+
 **Location:** `.claude/commands/{command-name}.md`
+
+**位置：** `.claude/commands/{command-name}.md`
 
 **📄 Examples:**
 - [onboard.md](.claude/commands/onboard.md) - Deep task exploration
@@ -743,7 +1011,15 @@ Custom commands invoked with `/command-name`.
 - [code-quality.md](.claude/commands/code-quality.md) - Quality checks
 - [docs-sync.md](.claude/commands/docs-sync.md) - Documentation alignment
 
+**📄 範例：**
+- [onboard.md](.claude/commands/onboard.md) - 深度任務探索
+- [pr-review.md](.claude/commands/pr-review.md) - PR 審查工作流程
+- [pr-summary.md](.claude/commands/pr-summary.md) - 生成 PR 描述
+- [code-quality.md](.claude/commands/code-quality.md) - 品質檢查
+- [docs-sync.md](.claude/commands/docs-sync.md) - 文件對齊
+
 #### Command Format
+#### 指令格式
 
 ```markdown
 ---
@@ -761,11 +1037,16 @@ Your task is to: $ARGUMENTS
 ```
 
 #### Variables
+#### 變數
 
 - `$ARGUMENTS` - All arguments as single string
 - `$1`, `$2`, `$3` - Individual positional arguments
 
+- `$ARGUMENTS` - 所有參數作為單一字串
+- `$1`、`$2`、`$3` - 個別位置參數
+
 #### Inline Bash
+#### 內嵌 Bash
 
 ```markdown
 Current branch: !`git branch --show-current`
@@ -775,8 +1056,11 @@ Recent commits: !`git log --oneline -5`
 ---
 
 ## GitHub Actions Workflows
+## GitHub Actions 工作流程
 
 Automate code review, quality checks, and maintenance with Claude Code.
+
+使用 Claude Code 自動化程式碼審查、品質檢查和維護。
 
 **📄 Examples:**
 - [pr-claude-code-review.yml](.github/workflows/pr-claude-code-review.yml) - Auto PR review
@@ -784,9 +1068,18 @@ Automate code review, quality checks, and maintenance with Claude Code.
 - [scheduled-claude-code-quality.yml](.github/workflows/scheduled-claude-code-quality.yml) - Weekly quality review
 - [scheduled-claude-code-dependency-audit.yml](.github/workflows/scheduled-claude-code-dependency-audit.yml) - Biweekly dependency updates
 
+**📄 範例：**
+- [pr-claude-code-review.yml](.github/workflows/pr-claude-code-review.yml) - 自動 PR 審查
+- [scheduled-claude-code-docs-sync.yml](.github/workflows/scheduled-claude-code-docs-sync.yml) - 每月文件同步
+- [scheduled-claude-code-quality.yml](.github/workflows/scheduled-claude-code-quality.yml) - 每週品質審查
+- [scheduled-claude-code-dependency-audit.yml](.github/workflows/scheduled-claude-code-dependency-audit.yml) - 雙週依賴更新
+
 ### PR Code Review
+### PR 程式碼審查
 
 Automatically reviews PRs and responds to `@claude` mentions.
+
+自動審查 PR 並回應 `@claude` 提及。
 
 ```yaml
 name: PR - Claude Code Review
@@ -819,6 +1112,7 @@ jobs:
 ```
 
 ### Scheduled Workflows
+### 定期工作流程
 
 | Workflow | Schedule | Purpose |
 |----------|----------|---------|
@@ -826,12 +1120,23 @@ jobs:
 | [Docs Sync](.github/workflows/scheduled-claude-code-docs-sync.yml) | Monthly (1st) | Ensures docs align with code changes |
 | [Dependency Audit](.github/workflows/scheduled-claude-code-dependency-audit.yml) | Biweekly (1st & 15th) | Safe dependency updates with testing |
 
+| 工作流程 | 排程 | 目的 |
+|----------|----------|---------|
+| [程式碼品質](.github/workflows/scheduled-claude-code-quality.yml) | 每週（週日） | 審查隨機目錄，自動修復問題 |
+| [文件同步](.github/workflows/scheduled-claude-code-docs-sync.yml) | 每月（1 日） | 確保文件與程式碼變更一致 |
+| [依賴審計](.github/workflows/scheduled-claude-code-dependency-audit.yml) | 雙週（1 日和 15 日） | 透過測試進行安全的依賴更新 |
+
 ### Setup Required
+### 所需設定
 
 Add `ANTHROPIC_API_KEY` to your repository secrets:
 - Settings → Secrets and variables → Actions → New repository secret
 
+將 `ANTHROPIC_API_KEY` 新增到您的程式碼庫機密：
+- Settings → Secrets and variables → Actions → New repository secret
+
 ### Cost Estimate
+### 成本估算
 
 | Workflow | Frequency | Est. Cost |
 |----------|-----------|-----------|
@@ -840,13 +1145,24 @@ Add `ANTHROPIC_API_KEY` to your repository secrets:
 | Dependency Audit | Biweekly | ~$0.20 - $1.00 |
 | Code Quality | Weekly | ~$1.00 - $5.00 |
 
+| 工作流程 | 頻率 | 預估成本 |
+|----------|-----------|-----------|
+| PR 審查 | 每個 PR | ~$0.05 - $0.50 |
+| 文件同步 | 每月 | ~$0.50 - $2.00 |
+| 依賴審計 | 雙週 | ~$0.20 - $1.00 |
+| 程式碼品質 | 每週 | ~$1.00 - $5.00 |
+
 **Estimated monthly total:** ~$10 - $50 (depending on PR volume)
+
+**預估每月總計：** ~$10 - $50（取決於 PR 數量）
 
 ---
 
 ## Best Practices
+## 最佳實踐
 
 ### 1. Start with CLAUDE.md
+### 1. 從 CLAUDE.md 開始
 
 Your `CLAUDE.md` is the foundation. Include:
 - Stack overview
@@ -854,14 +1170,27 @@ Your `CLAUDE.md` is the foundation. Include:
 - Critical rules
 - Directory structure
 
+您的 `CLAUDE.md` 是基礎。應包含：
+- 技術堆疊概述
+- 關鍵指令
+- 關鍵規則
+- 目錄結構
+
 ### 2. Build Skills Incrementally
+### 2. 逐步建立技能
 
 Don't try to document everything at once:
 1. Start with your most common patterns
 2. Add skills as pain points emerge
 3. Keep each skill focused on one domain
 
+不要試圖一次記錄所有內容：
+1. 從最常見的模式開始
+2. 隨著痛點出現而新增技能
+3. 保持每個技能專注於一個領域
+
 ### 3. Use Hooks for Automation
+### 3. 使用鉤子進行自動化
 
 Let hooks handle repetitive tasks:
 - Auto-format on save
@@ -869,7 +1198,14 @@ Let hooks handle repetitive tasks:
 - Regenerate types when schemas change
 - Block edits on protected branches
 
+讓鉤子處理重複性任務：
+- 儲存時自動格式化
+- 測試檔案變更時執行測試
+- schema 變更時重新生成類型
+- 阻止在受保護分支上進行編輯
+
 ### 4. Create Agents for Complex Workflows
+### 4. 為複雜工作流程建立代理
 
 Agents are great for:
 - Code review (with your team's checklist)
@@ -877,7 +1213,14 @@ Agents are great for:
 - Debugging workflows
 - Onboarding to tasks
 
+代理非常適合：
+- 程式碼審查（使用團隊的檢查清單）
+- PR 建立和管理
+- 除錯工作流程
+- 任務導入
+
 ### 5. Leverage GitHub Actions
+### 5. 利用 GitHub Actions
 
 Automate maintenance:
 - PR reviews on every PR
@@ -885,16 +1228,29 @@ Automate maintenance:
 - Monthly docs alignment
 - Dependency updates
 
+自動化維護：
+- 每個 PR 的審查
+- 每週品質檢查
+- 每月文件對齊
+- 依賴更新
+
 ### 6. Version Control Your Config
+### 6. 版本控制您的配置
 
 Commit everything except:
 - `settings.local.json` (personal preferences)
 - `CLAUDE.local.md` (personal notes)
 - User-specific credentials
 
+提交所有內容，除了：
+- `settings.local.json`（個人偏好）
+- `CLAUDE.local.md`（個人筆記）
+- 使用者特定的憑證
+
 ---
 
 ## Examples in This Repository
+## 本程式碼庫中的範例
 
 | File | Description |
 |------|-------------|
@@ -929,16 +1285,57 @@ Commit everything except:
 | [.github/workflows/scheduled-claude-code-quality.yml](.github/workflows/scheduled-claude-code-quality.yml) | Weekly quality review |
 | [.github/workflows/scheduled-claude-code-dependency-audit.yml](.github/workflows/scheduled-claude-code-dependency-audit.yml) | Biweekly dependency audit |
 
+| 檔案 | 描述 |
+|------|-------------|
+| [CLAUDE.md](CLAUDE.md) | 範例專案記憶檔案 |
+| [.claude/settings.json](.claude/settings.json) | 完整 hooks 配置 |
+| [.claude/settings.md](.claude/settings.md) | 易讀的 hooks 文件 |
+| [.mcp.json](.mcp.json) | MCP 伺服器配置（JIRA、GitHub、Slack 等） |
+| **代理** | |
+| [.claude/agents/code-reviewer.md](.claude/agents/code-reviewer.md) | 全面的程式碼審查代理 |
+| [.claude/agents/github-workflow.md](.claude/agents/github-workflow.md) | Git 工作流程代理 |
+| **指令** | |
+| [.claude/commands/onboard.md](.claude/commands/onboard.md) | 深度任務探索 |
+| [.claude/commands/ticket.md](.claude/commands/ticket.md) | **JIRA/Linear 工單工作流程（讀取 → 實作 → 更新）** |
+| [.claude/commands/pr-review.md](.claude/commands/pr-review.md) | PR 審查工作流程 |
+| [.claude/commands/pr-summary.md](.claude/commands/pr-summary.md) | 生成 PR 摘要 |
+| [.claude/commands/code-quality.md](.claude/commands/code-quality.md) | 品質檢查 |
+| [.claude/commands/docs-sync.md](.claude/commands/docs-sync.md) | 文件同步 |
+| **鉤子** | |
+| [.claude/hooks/skill-eval.sh](.claude/hooks/skill-eval.sh) | 技能評估包裝器 |
+| [.claude/hooks/skill-eval.js](.claude/hooks/skill-eval.js) | Node.js 技能匹配引擎 |
+| [.claude/hooks/skill-rules.json](.claude/hooks/skill-rules.json) | 模式匹配規則 |
+| **技能** | |
+| [.claude/skills/testing-patterns/SKILL.md](.claude/skills/testing-patterns/SKILL.md) | TDD、工廠函式、模擬 |
+| [.claude/skills/systematic-debugging/SKILL.md](.claude/skills/systematic-debugging/SKILL.md) | 四階段除錯 |
+| [.claude/skills/react-ui-patterns/SKILL.md](.claude/skills/react-ui-patterns/SKILL.md) | 載入/錯誤/空白狀態 |
+| [.claude/skills/graphql-schema/SKILL.md](.claude/skills/graphql-schema/SKILL.md) | 查詢、mutation、程式碼生成 |
+| [.claude/skills/core-components/SKILL.md](.claude/skills/core-components/SKILL.md) | 設計系統、設計令牌 |
+| [.claude/skills/formik-patterns/SKILL.md](.claude/skills/formik-patterns/SKILL.md) | 表單處理、驗證 |
+| **GitHub 工作流程** | |
+| [.github/workflows/pr-claude-code-review.yml](.github/workflows/pr-claude-code-review.yml) | 自動 PR 審查 |
+| [.github/workflows/scheduled-claude-code-docs-sync.yml](.github/workflows/scheduled-claude-code-docs-sync.yml) | 每月文件同步 |
+| [.github/workflows/scheduled-claude-code-quality.yml](.github/workflows/scheduled-claude-code-quality.yml) | 每週品質審查 |
+| [.github/workflows/scheduled-claude-code-dependency-audit.yml](.github/workflows/scheduled-claude-code-dependency-audit.yml) | 雙週依賴審計 |
+
 ---
 
 ## Learn More
+## 了解更多
 
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [Claude Code Action](https://github.com/anthropics/claude-code-action) - GitHub Action
+- [Anthropic API](https://docs.anthropic.com/en/api)
+
+- [Claude Code 文件](https://docs.anthropic.com/en/docs/claude-code)
 - [Claude Code Action](https://github.com/anthropics/claude-code-action) - GitHub Action
 - [Anthropic API](https://docs.anthropic.com/en/api)
 
 ---
 
 ## License
+## 授權
 
 MIT - Use this as a template for your own projects.
+
+MIT - 使用此作為您自己專案的範本。


### PR DESCRIPTION
Add Traditional Chinese translations alongside English content for all documentation files to support bilingual learning purposes.

Translated files:
- Core docs: README.md, CLAUDE.md, .claude/settings.md
- Skills: All 6 SKILL.md files + skills/README.md
- Commands: All 6 command files (onboard, pr-review, pr-summary, etc.)
- Agents: code-reviewer.md, github-workflow.md
- GitHub Workflows: All 4 workflow files with bilingual comments

Translation format:
- Section headers show English first, then Chinese
- Paragraphs show English followed by Chinese translation
- Code blocks, paths, and commands remain in English
- Technical terms preserved for accuracy