### PR TITLE
fix: add missing name frontmatter to 5 slash commands

### DIFF
--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -1,4 +1,5 @@
 ---
+name: code-quality
 description: Run code quality checks on a directory
 allowed-tools: Read, Glob, Grep, Bash(npm:*), Bash(npx:*)
 ---

--- a/.claude/commands/docs-sync.md
+++ b/.claude/commands/docs-sync.md
@@ -1,4 +1,5 @@
 ---
+name: docs-sync
 description: Check if documentation is in sync with code
 allowed-tools: Read, Glob, Grep, Bash(git:*)
 ---

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,4 +1,5 @@
 ---
+name: pr-review
 description: Review a pull request using project standards
 allowed-tools: Read, Glob, Grep, Bash(git:*), Bash(gh:*)
 ---

--- a/.claude/commands/pr-summary.md
+++ b/.claude/commands/pr-summary.md
@@ -1,4 +1,5 @@
 ---
+name: pr-summary
 description: Generate a summary for the current branch changes
 allowed-tools: Bash(git:*)
 ---

--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -1,4 +1,5 @@
 ---
+name: ticket
 description: Work on a JIRA/Linear ticket end-to-end
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git:*), Bash(gh:*), Bash(npm:*), mcp__jira__*, mcp__github__*, mcp__linear__*
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Five slash commands are missing the `name` frontmatter field:

- `.claude/commands/code-quality.md`
- `.claude/commands/docs-sync.md`
- `.claude/commands/pr-review.md`
- `.claude/commands/pr-summary.md`
- `.claude/commands/ticket.md`

Claude Code uses the `name` field to register a command so it can be invoked as `/name`. Without it, the command cannot be discovered or called by name — the slash command simply doesn't work.

## Fix

Added `name: <command>` to each file's frontmatter, using the same value as the filename (the conventional default). For example:

```diff
 ---
+name: code-quality
 description: Run code quality checks on a directory
 allowed-tools: Read, Glob, Grep, Bash(npm:*), Bash(npx:*)
 ---
```

No behavior is changed — this is a pure registration fix.