### PR TITLE
fix: add complete frontmatter to onboard.md

### DIFF
--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,3 +1,9 @@
+---
+name: onboard
+description: Onboard Claude to a new task by exploring the codebase and preparing a task brief
+allowed-tools: Read, Glob, Grep, Write, Bash(find:*)
+---
+
 # Onboard
 
 You are given the following context:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`.claude/commands/onboard.md` has no frontmatter at all. The other five commands in this repo all have a proper `---` frontmatter block; `onboard.md` starts directly with `# Onboard`.

This causes three concrete problems:

1. **Missing `name`** — the `/onboard` command cannot be registered or invoked by name
2. **Missing `description`** — the command has no discoverable description for the UI or skill-routing hooks
3. **Missing `allowed-tools`** — Claude has no declared tool boundary, so it may use arbitrary tools when running this command

## Fix

Added a standard frontmatter block consistent with the repo's other commands:

```diff
+---
+name: onboard
+description: Onboard Claude to a new task by exploring the codebase and preparing a task brief
+allowed-tools: Read, Glob, Grep, Write, Bash(find:*)
+---
+
 # Onboard
```

The `allowed-tools` list covers exactly what the command body needs:
- `Read`, `Glob`, `Grep` — codebase exploration
- `Write` — creating the `.claude/tasks/[TASK_ID]/onboarding.md` file
- `Bash(find:*)` — optional filesystem discovery

No behavior is changed in the command body.