### PR TITLE
fix: quote $ARGUMENTS in shell invocations

### DIFF
--- a/.claude/commands/code-quality.md
+++ b/.claude/commands/code-quality.md
@@ -15,7 +15,7 @@ Review code quality in: $ARGUMENTS
 
 2. **Run automated checks**:
    ```bash
-   npm run lint -- $ARGUMENTS
+   npm run lint -- "$ARGUMENTS"
    npm run typecheck
    ```
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -10,8 +10,8 @@ Review the pull request: $ARGUMENTS
 ## Instructions
 
 1. **Get PR information**:
-   - Run `gh pr view $ARGUMENTS` to get PR details
-   - Run `gh pr diff $ARGUMENTS` to see changes
+   - Run `gh pr view "$ARGUMENTS"` to get PR details
+   - Run `gh pr diff "$ARGUMENTS"` to see changes
 
 2. **Read review standards**:
    - Read `.claude/agents/code-reviewer.md` for the review checklist


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low)

Two commands embed `$ARGUMENTS` unquoted in shell code blocks:

**`.claude/commands/pr-review.md`**
```
gh pr view $ARGUMENTS
gh pr diff $ARGUMENTS
```

**`.claude/commands/code-quality.md`**
```
npm run lint -- $ARGUMENTS
```

When the shell (or AI-generated shell invocation) expands an unquoted variable, any whitespace or metacharacters in the value cause word-splitting. This means `$ARGUMENTS` containing spaces produces multiple tokens instead of one argument, which can:
- Bypass the `Bash(gh:*)` restriction intent (extra tokens are separate arguments)
- Inject unintended flags into `npm run lint`

## Fix

Wrap the variable in double quotes in both files:

```diff
-   - Run `gh pr view $ARGUMENTS` to get PR details
-   - Run `gh pr diff $ARGUMENTS` to see changes
+   - Run `gh pr view "$ARGUMENTS"` to get PR details
+   - Run `gh pr diff "$ARGUMENTS"` to see changes
```

```diff
-   npm run lint -- $ARGUMENTS
+   npm run lint -- "$ARGUMENTS"
```

This is a minimal, targeted fix with no change to command behavior for well-formed input.